### PR TITLE
[PGPRO-5681] AQO: try to replace query hash with QueryID based on jum…

### DIFF
--- a/aqo--1.0.sql
+++ b/aqo--1.0.sql
@@ -2,20 +2,20 @@
 \echo Use "CREATE EXTENSION aqo" to load this file. \quit
 
 CREATE TABLE public.aqo_queries (
-	query_hash		int PRIMARY KEY,
+	query_hash		bigint PRIMARY KEY,
 	learn_aqo		boolean NOT NULL,
 	use_aqo			boolean NOT NULL,
-	fspace_hash		int NOT NULL,
+	fspace_hash		bigint NOT NULL,
 	auto_tuning		boolean NOT NULL
 );
 
 CREATE TABLE public.aqo_query_texts (
-	query_hash		int PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
+	query_hash		bigint PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
 	query_text		varchar NOT NULL
 );
 
 CREATE TABLE public.aqo_query_stat (
-	query_hash		int PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
+	query_hash		bigint PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
 	execution_time_with_aqo					double precision[],
 	execution_time_without_aqo				double precision[],
 	planning_time_with_aqo					double precision[],
@@ -27,7 +27,7 @@ CREATE TABLE public.aqo_query_stat (
 );
 
 CREATE TABLE public.aqo_data (
-	fspace_hash		int NOT NULL REFERENCES public.aqo_queries ON DELETE CASCADE,
+	fspace_hash		bigint NOT NULL REFERENCES public.aqo_queries ON DELETE CASCADE,
 	fsspace_hash	int NOT NULL,
 	nfeatures		int NOT NULL,
 	features		double precision[][],

--- a/aqo--1.1--1.2.sql
+++ b/aqo--1.1--1.2.sql
@@ -28,12 +28,12 @@ DROP FUNCTION aqo_migrate_to_1_2_get_pk(regclass);
 --
 
 -- Show query state at the AQO knowledge base
-CREATE OR REPLACE FUNCTION public.aqo_status(hash int)
+CREATE OR REPLACE FUNCTION public.aqo_status(hash bigint)
 RETURNS TABLE (
 	"learn"			BOOL,
 	"use aqo"		BOOL,
 	"auto tune"		BOOL,
-	"fspace hash"	INT,
+	"fspace hash"	bigINT,
 	"t_naqo"		TEXT,
 	"err_naqo"		TEXT,
 	"iters"			BIGINT,
@@ -63,7 +63,7 @@ WHERE (aqs.query_hash = aq.query_hash) AND
 	aqs.query_hash = $1;
 $func$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION public.aqo_enable_query(hash int)
+CREATE OR REPLACE FUNCTION public.aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $func$
 UPDATE public.aqo_queries SET
@@ -72,7 +72,7 @@ UPDATE public.aqo_queries SET
 	WHERE query_hash = $1;
 $func$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION public.aqo_disable_query(hash int)
+CREATE OR REPLACE FUNCTION public.aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $func$
 UPDATE public.aqo_queries SET
@@ -82,7 +82,7 @@ UPDATE public.aqo_queries SET
 	WHERE query_hash = $1;
 $func$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION public.aqo_clear_hist(hash int)
+CREATE OR REPLACE FUNCTION public.aqo_clear_hist(hash bigint)
 RETURNS VOID
 AS $func$
 DELETE FROM public.aqo_data WHERE fspace_hash=$1;
@@ -96,7 +96,7 @@ SELECT query_hash FROM public.aqo_query_stat aqs
 	WHERE -1 = ANY (cardinality_error_with_aqo::double precision[]);
 $func$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION public.aqo_drop(hash int)
+CREATE OR REPLACE FUNCTION public.aqo_drop(hash bigint)
 RETURNS VOID
 AS $func$
 DELETE FROM public.aqo_queries aq WHERE (aq.query_hash = $1);

--- a/aqo--1.2--1.3.sql
+++ b/aqo--1.2--1.3.sql
@@ -10,7 +10,7 @@ DECLARE
     aqo_query_texts_row aqo_query_texts%ROWTYPE;
     aqo_query_stat_row aqo_query_stat%ROWTYPE;
     oid_var oid;
-    fspace_hash_var int;
+    fspace_hash_var bigint;
     delete_row boolean DEFAULT false;
 BEGIN
   RAISE NOTICE 'Cleaning aqo_data records';
@@ -89,8 +89,8 @@ $$ LANGUAGE plpgsql;
 --
 CREATE OR REPLACE FUNCTION public.top_time_queries(n int)
   RETURNS TABLE(num bigint,
-                fspace_hash int,
-                query_hash int,
+                fspace_hash bigint,
+                query_hash bigint,
                 execution_time float,
                 deviation float
                )
@@ -115,8 +115,8 @@ $$ LANGUAGE plpgsql;
 --
 CREATE OR REPLACE FUNCTION public.top_error_queries(n int)
   RETURNS TABLE(num bigint,
-                fspace_hash int,
-                query_hash int,
+                fspace_hash bigint,
+                query_hash bigint,
                 error float,
                 deviation float
                )
@@ -152,7 +152,7 @@ $$ LANGUAGE plpgsql;
 --
 CREATE OR REPLACE FUNCTION public.aqo_show_classes()
 RETURNS TABLE (
-  query_hash integer,	-- Query class identifier
+  query_hash bigint,	-- Query class identifier integer
   execution_time float,	-- Sum of execution times of all queries belong to a class.
   counter integer		-- Number of executions of queries of a class.
 )

--- a/aqo--1.2.sql
+++ b/aqo--1.2.sql
@@ -2,20 +2,20 @@
 \echo Use "CREATE EXTENSION aqo" to load this file. \quit
 
 CREATE TABLE public.aqo_queries (
-	query_hash		int CONSTRAINT aqo_queries_query_hash_idx PRIMARY KEY,
+	query_hash		bigint CONSTRAINT aqo_queries_query_hash_idx PRIMARY KEY,
 	learn_aqo		boolean NOT NULL,
 	use_aqo			boolean NOT NULL,
-	fspace_hash		int NOT NULL,
+	fspace_hash		bigint NOT NULL,
 	auto_tuning		boolean NOT NULL
 );
 
 CREATE TABLE public.aqo_query_texts (
-	query_hash		int CONSTRAINT aqo_query_texts_query_hash_idx PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
+	query_hash		bigint CONSTRAINT aqo_query_texts_query_hash_idx PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
 	query_text		text NOT NULL
 );
 
 CREATE TABLE public.aqo_query_stat (
-	query_hash		int CONSTRAINT aqo_query_stat_idx PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
+	query_hash		bigint CONSTRAINT aqo_query_stat_idx PRIMARY KEY REFERENCES public.aqo_queries ON DELETE CASCADE,
 	execution_time_with_aqo					double precision[],
 	execution_time_without_aqo				double precision[],
 	planning_time_with_aqo					double precision[],
@@ -27,7 +27,7 @@ CREATE TABLE public.aqo_query_stat (
 );
 
 CREATE TABLE public.aqo_data (
-	fspace_hash		int NOT NULL REFERENCES public.aqo_queries ON DELETE CASCADE,
+	fspace_hash		bigint NOT NULL REFERENCES public.aqo_queries ON DELETE CASCADE,
 	fsspace_hash	int NOT NULL,
 	nfeatures		int NOT NULL,
 	features		double precision[][],
@@ -52,12 +52,12 @@ CREATE TRIGGER aqo_queries_invalidate AFTER UPDATE OR DELETE OR TRUNCATE
 --
 
 -- Show query state at the AQO knowledge base
-CREATE FUNCTION public.aqo_status(hash int)
+CREATE FUNCTION public.aqo_status(hash bigint)
 RETURNS TABLE (
 	"learn"			BOOL,
 	"use aqo"		BOOL,
 	"auto tune"		BOOL,
-	"fspace hash"	INT,
+	"fspace hash"	bigINT,
 	"t_naqo"		TEXT,
 	"err_naqo"		TEXT,
 	"iters"			BIGINT,
@@ -87,7 +87,7 @@ WHERE (aqs.query_hash = aq.query_hash) AND
 	aqs.query_hash = $1;
 $func$ LANGUAGE SQL;
 
-CREATE FUNCTION public.aqo_enable_query(hash int)
+CREATE FUNCTION public.aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $func$
 UPDATE public.aqo_queries SET
@@ -96,7 +96,7 @@ UPDATE public.aqo_queries SET
 	WHERE query_hash = $1;
 $func$ LANGUAGE SQL;
 
-CREATE FUNCTION public.aqo_disable_query(hash int)
+CREATE FUNCTION public.aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $func$
 UPDATE public.aqo_queries SET
@@ -106,7 +106,7 @@ UPDATE public.aqo_queries SET
 	WHERE query_hash = $1;
 $func$ LANGUAGE SQL;
 
-CREATE FUNCTION public.aqo_clear_hist(hash int)
+CREATE FUNCTION public.aqo_clear_hist(hash bigint)
 RETURNS VOID
 AS $func$
 DELETE FROM public.aqo_data WHERE fspace_hash=$1;
@@ -120,7 +120,7 @@ SELECT query_hash FROM public.aqo_query_stat aqs
 	WHERE -1 = ANY (cardinality_error_with_aqo::double precision[]);
 $func$ LANGUAGE SQL;
 
-CREATE FUNCTION public.aqo_drop(hash int)
+CREATE FUNCTION public.aqo_drop(hash bigint)
 RETURNS VOID
 AS $func$
 DELETE FROM public.aqo_queries aq WHERE (aq.query_hash = $1);

--- a/aqo.c
+++ b/aqo.c
@@ -131,7 +131,7 @@ aqo_free_callback(ResourceReleasePhase phase,
 
 	if (isTopLevel)
 	{
-		list_free(cur_classes);
+		list_free_deep(cur_classes);
 		cur_classes = NIL;
 	}
 }

--- a/aqo.h
+++ b/aqo.h
@@ -202,8 +202,8 @@ typedef struct
 /* Parameters for current query */
 typedef struct QueryContextData
 {
-	int			query_hash;
-	int			fspace_hash;
+	uint64		query_hash;
+	uint64		fspace_hash;
 	bool		learn_aqo;
 	bool		use_aqo;
 	bool		auto_tuning;
@@ -280,24 +280,24 @@ int get_clause_hash(Expr *clause, int nargs, int *args_hash, int *eclass_hash);
 
 
 /* Storage interaction */
-extern bool find_query(int qhash, Datum *search_values, bool *search_nulls);
-extern bool update_query(int qhash, int fhash,
+extern bool find_query(uint64 qhash, Datum *search_values, bool *search_nulls);
+extern bool update_query(uint64 qhash, uint64 fhash,
 						 bool learn_aqo, bool use_aqo, bool auto_tuning);
-extern bool add_query_text(int query_hash, const char *query_string);
-extern bool load_fss(int fhash, int fss_hash,
+extern bool add_query_text(uint64 query_hash, const char *query_string);
+extern bool load_fss(uint64 fhash, int fss_hash,
 					 int ncols, double **matrix, double *targets, int *rows,
 					 List **relids);
-extern bool update_fss(int fhash, int fss_hash, int nrows, int ncols,
+extern bool update_fss(uint64 fhash, int fss_hash, int nrows, int ncols,
 					   double **matrix, double *targets, List *relids);
-QueryStat *get_aqo_stat(int query_hash);
-void update_aqo_stat(int query_hash, QueryStat * stat);
+QueryStat *get_aqo_stat(uint64 query_hash);
+void update_aqo_stat(uint64 query_hash, QueryStat * stat);
 extern bool my_index_insert(Relation indexRelation,	Datum *values, bool *isnull,
 							ItemPointer heap_t_ctid, Relation heapRelation,
 							IndexUniqueCheck checkUnique);
 void init_deactivated_queries_storage(void);
 void fini_deactivated_queries_storage(void);
-extern bool query_is_deactivated(int query_hash);
-extern void add_deactivated_query(int query_hash);
+extern bool query_is_deactivated(uint64 query_hash);
+extern void add_deactivated_query(uint64 query_hash);
 
 /* Query preprocessing hooks */
 extern void print_into_explain(PlannedStmt *plannedstmt, IntoClause *into,
@@ -324,7 +324,7 @@ extern int OkNNr_learn(int matrix_rows, int matrix_cols,
 			double *features, double target);
 
 /* Automatic query tuning */
-extern void automatical_query_tuning(int query_hash, QueryStat * stat);
+extern void automatical_query_tuning(uint64 query_hash, QueryStat * stat);
 
 /* Utilities */
 int			int_cmp(const void *a, const void *b);

--- a/auto_tuning.c
+++ b/auto_tuning.c
@@ -144,7 +144,7 @@ is_in_infinite_loop_cq(double *elems, int nelems)
  * this query to false.
  */
 void
-automatical_query_tuning(int query_hash, QueryStat * stat)
+automatical_query_tuning(uint64 query_hash, QueryStat * stat)
 {
 	double		unstability = auto_tuning_exploration;
 	double		t_aqo,
@@ -202,7 +202,7 @@ automatical_query_tuning(int query_hash, QueryStat * stat)
 		query_context.use_aqo = (random() / ((double) MAX_RANDOM_VALUE + 1)) < p_use;
 		query_context.learn_aqo = query_context.use_aqo;
 	}
-
+	
 	if (num_iterations <= auto_tuning_max_iterations || p_use > 0.5)
 		update_query(query_hash,
 					 query_context.fspace_hash,

--- a/expected/aqo_CVE-2020-14350.out
+++ b/expected/aqo_CVE-2020-14350.out
@@ -48,12 +48,12 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_status(hash int)
+CREATE FUNCTION aqo_status(hash bigint)
 RETURNS TABLE (
   "learn"       BOOL,
   "use aqo"     BOOL,
   "auto tune"   BOOL,
-  "fspace hash" INT,
+  "fspace hash" bigINT,
   "t_naqo"      TEXT,
   "err_naqo"    TEXT,
   "iters"       BIGINT,
@@ -70,12 +70,12 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 ERROR:  function "aqo_status" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_status(hash int)
+CREATE OR REPLACE FUNCTION aqo_status(hash bigint)
 RETURNS TABLE (
   "learn"       BOOL,
   "use aqo"     BOOL,
   "auto tune"   BOOL,
-  "fspace hash" INT,
+  "fspace hash" bigINT,
   "t_naqo"      TEXT,
   "err_naqo"    TEXT,
   "iters"       BIGINT,
@@ -102,7 +102,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_status(int);
+DROP FUNCTION aqo_status(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 3
@@ -115,7 +115,7 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_enable_query(hash int)
+CREATE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -126,7 +126,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 ERROR:  function "aqo_enable_query" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_enable_query(hash int)
+CREATE OR REPLACE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -148,7 +148,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_enable_query(int);
+DROP FUNCTION aqo_enable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 4
@@ -161,7 +161,7 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_disable_query(hash int)
+CREATE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -172,7 +172,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 ERROR:  function "aqo_disable_query" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_disable_query(hash int)
+CREATE OR REPLACE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -194,7 +194,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_disable_query(int);
+DROP FUNCTION aqo_disable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 5
@@ -207,7 +207,7 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_clear_hist(hash int)
+CREATE FUNCTION aqo_clear_hist(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -218,7 +218,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 ERROR:  function "aqo_clear_hist" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_clear_hist(hash int)
+CREATE OR REPLACE FUNCTION aqo_clear_hist(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -240,7 +240,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_clear_hist(int);
+DROP FUNCTION aqo_clear_hist(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 6
@@ -253,7 +253,7 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_drop(hash int)
+CREATE FUNCTION aqo_drop(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -264,7 +264,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 ERROR:  function "aqo_drop" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_drop(hash int)
+CREATE OR REPLACE FUNCTION aqo_drop(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -286,7 +286,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_drop(int);
+DROP FUNCTION aqo_drop(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 7

--- a/expected/gucs.out
+++ b/expected/gucs.out
@@ -41,8 +41,8 @@ SET aqo.log_ignorance = 'on';
              Table "public.aqo_ignorance"
   Column   |  Type   | Collation | Nullable | Default 
 -----------+---------+-----------+----------+---------
- qhash     | integer |           |          | 
- fhash     | integer |           |          | 
+ qhash     | bigint  |           |          | 
+ fhash     | bigint  |           |          | 
  fss_hash  | integer |           |          | 
  node_type | integer |           |          | 
  node      | text    |           |          | 

--- a/expected/plancache.out
+++ b/expected/plancache.out
@@ -15,7 +15,7 @@ CREATE FUNCTION f1() RETURNS TABLE (
 ) AS $$
 DECLARE
   i				integer;
-  qhash			integer;
+  qhash			bigint;
 BEGIN
   PREPARE fooplan (int) AS SELECT count(*) FROM test WHERE x = $1;
 

--- a/hash.c
+++ b/hash.c
@@ -55,25 +55,74 @@ static List **get_clause_args_ptr(Expr *clause);
 static bool clause_is_eq_clause(Expr *clause);
 
 /*
- * Computes hash for given query.
+ * Computes hash for given query.Query Identifier: =
  * Hash is supposed to be constant-insensitive.
  * XXX: Hashing depend on Oids of database objects. It is restrict usability of
  * the AQO knowledge base by current database at current Postgres instance.
  */
-int
+uint64
 get_query_hash(Query *parse, const char *query_text)
 {
 	char	   *str_repr;
-	int			hash;
+	uint64			hash;
 
 	/* XXX: remove_locations and remove_consts are heavy routines. */
 	str_repr = remove_locations(remove_consts(nodeToString(parse)));
-	hash = DatumGetInt32(hash_any((const unsigned char *) str_repr,
-								  strlen(str_repr) * sizeof(*str_repr)));
+	hash = DatumGetUInt64(hash_any_extended((void *) str_repr, strlen(str_repr),0));
 	pfree(str_repr);
 
 	return hash;
 }
+
+/*********************************************************************************
+ *
+ * Because List natively works with OID, integer and a postgres node types,
+ * implement separate set of functions which manages list of uint64 values
+ * (need for the query hash type).
+ *
+ ********************************************************************************/
+
+bool
+list_member_uint64(const List *list, uint64 datum)
+{
+	const ListCell *cell;
+
+	foreach(cell, list)
+	{
+		if (*((uint64 *)lfirst(cell)) == datum)
+			return true;
+	}
+
+	return false;
+}
+
+List *
+lappend_uint64(List *list, uint64 datum)
+{
+	uint64 *val = palloc(sizeof(uint64));
+
+	*val = datum;
+	list = lappend(list, (void *) val);
+	return list;
+}
+
+List *
+ldelete_uint64(List *list, uint64 datum)
+{
+	ListCell *cell;
+
+	foreach(cell, list)
+	{
+		if (*((uint64 *)lfirst(cell)) == datum)
+		{
+			list = list_delete_ptr(list, lfirst(cell));
+			return list;
+		}
+	}
+	return list;
+}
+
+/********************************************************************************/
 
 int
 get_grouped_exprs_hash(int child_fss, List *group_exprs)

--- a/hash.h
+++ b/hash.h
@@ -3,7 +3,10 @@
 
 #include "nodes/pg_list.h"
 
-extern int get_query_hash(Query *parse, const char *query_text);
+extern uint64 get_query_hash(Query *parse, const char *query_text);
+extern bool list_member_uint64(const List *list, uint64 datum);
+extern List *lappend_uint64(List *list, uint64 datum);
+extern List *ldelete_uint64(List *list, uint64 datum);
 extern int get_fss_for_object(List *relidslist, List *clauselist,
 							  List *selectivities, int *nfeatures,
 							  double **features);

--- a/ignorance.h
+++ b/ignorance.h
@@ -5,6 +5,6 @@ extern bool aqo_log_ignorance;
 
 extern void set_ignorance(bool newval, void *extra);
 extern bool create_ignorance_table(bool fail_ok);
-extern void update_ignorance(int qhash, int fhash, int fss_hash, Plan *plan);
+extern void update_ignorance(uint64 qhash, uint64 fhash, int fss_hash, Plan *plan);//?
 
 #endif /* IGNORANCE_H */

--- a/preprocessing.h
+++ b/preprocessing.h
@@ -3,7 +3,6 @@
 
 #include "nodes/pathnodes.h"
 #include "nodes/plannodes.h"
-
 extern PlannedStmt *aqo_planner(Query *parse,
 								const char *query_string,
 								int cursorOptions,

--- a/profile_mem.c
+++ b/profile_mem.c
@@ -14,7 +14,7 @@ static HTAB   *profile_mem_queries = NULL;
 
 typedef struct ProfileMemEntry
 {
-	int key;
+	uint64 key;
 	double time;
 	unsigned int counter;
 } ProfileMemEntry;
@@ -95,7 +95,7 @@ aqo_show_classes(PG_FUNCTION_ARGS)
 		Datum values[3];
 		bool  nulls[3] = {0, 0, 0};
 
-		values[0] = Int32GetDatum(entry->key);
+		values[0] = UInt64GetDatum(entry->key);
 		values[1] = Float8GetDatum(entry->time);
 		values[2] = UInt32GetDatum(entry->counter);
 
@@ -168,7 +168,7 @@ update_profile_mem_table(double total_time)
 		return;
 
 	Assert(profile_mem_queries);
-
+	Assert(query_context.query_hash>=0);
 	pentry = (ProfileMemEntry *) hash_search(profile_mem_queries,
 											 &query_context.query_hash,
 											 HASH_ENTER_NULL, &found);
@@ -232,7 +232,7 @@ profile_shmem_startup(void)
 	if (aqo_profile_classes <= 0)
 		return;
 
-	ctl.keysize = sizeof(int);
+	ctl.keysize = sizeof(uint64);
 	ctl.entrysize = sizeof(ProfileMemEntry);
 	profile_mem_queries = ShmemInitHash("aqo_profile_mem_queries",
 										aqo_profile_classes,

--- a/sql/aqo_CVE-2020-14350.sql
+++ b/sql/aqo_CVE-2020-14350.sql
@@ -43,12 +43,12 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_status(hash int)
+CREATE FUNCTION aqo_status(hash bigint)
 RETURNS TABLE (
   "learn"       BOOL,
   "use aqo"     BOOL,
   "auto tune"   BOOL,
-  "fspace hash" INT,
+  "fspace hash" bigINT,
   "t_naqo"      TEXT,
   "err_naqo"    TEXT,
   "iters"       BIGINT,
@@ -66,12 +66,12 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_status(hash int)
+CREATE OR REPLACE FUNCTION aqo_status(hash bigint)
 RETURNS TABLE (
   "learn"       BOOL,
   "use aqo"     BOOL,
   "auto tune"   BOOL,
-  "fspace hash" INT,
+  "fspace hash" bigINT,
   "t_naqo"      TEXT,
   "err_naqo"    TEXT,
   "iters"       BIGINT,
@@ -92,7 +92,7 @@ SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_status(int);
+DROP FUNCTION aqo_status(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 3
@@ -102,7 +102,7 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_enable_query(hash int)
+CREATE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -114,7 +114,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_enable_query(hash int)
+CREATE OR REPLACE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -129,7 +129,7 @@ SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_enable_query(int);
+DROP FUNCTION aqo_enable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 4
@@ -139,7 +139,7 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_disable_query(hash int)
+CREATE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -151,7 +151,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_disable_query(hash int)
+CREATE OR REPLACE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -166,7 +166,7 @@ SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_disable_query(int);
+DROP FUNCTION aqo_disable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 5
@@ -176,7 +176,7 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_clear_hist(hash int)
+CREATE FUNCTION aqo_clear_hist(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -188,7 +188,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_clear_hist(hash int)
+CREATE OR REPLACE FUNCTION aqo_clear_hist(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -203,7 +203,7 @@ SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_clear_hist(int);
+DROP FUNCTION aqo_clear_hist(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 6
@@ -213,7 +213,7 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_drop(hash int)
+CREATE FUNCTION aqo_drop(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -225,7 +225,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_drop(hash int)
+CREATE OR REPLACE FUNCTION aqo_drop(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -240,7 +240,7 @@ SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_drop(int);
+DROP FUNCTION aqo_drop(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 7

--- a/sql/plancache.sql
+++ b/sql/plancache.sql
@@ -18,7 +18,7 @@ CREATE FUNCTION f1() RETURNS TABLE (
 ) AS $$
 DECLARE
   i				integer;
-  qhash			integer;
+  qhash			bigint;
 BEGIN
   PREPARE fooplan (int) AS SELECT count(*) FROM test WHERE x = $1;
 

--- a/t/001_pgbench.pl
+++ b/t/001_pgbench.pl
@@ -1,10 +1,13 @@
 use strict;
 use warnings;
-use TestLib;
-use Test::More tests => 21;
-use PostgresNode;
 
-my $node = PostgresNode->new('aqotest');
+use Config;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+
+use Test::More tests => 21;
+
+my $node = PostgreSQL::Test::Cluster->new('aqotest');
 $node->init;
 $node->append_conf('postgresql.conf', qq{
 						shared_preload_libraries = 'aqo'

--- a/t/002_profiling.pl
+++ b/t/002_profiling.pl
@@ -4,11 +4,14 @@
 
 use strict;
 use warnings;
-use TestLib;
-use Test::More tests => 20;
-use PostgresNode;
 
-my $node = PostgresNode->new('profiling');
+use Config;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+
+use Test::More tests => 20;
+
+my $node = PostgreSQL::Test::Cluster->new('profiling');
 $node->init;
 $node->append_conf('postgresql.conf', qq{
 						aqo.mode = 'disabled'


### PR DESCRIPTION
…bling routine.

We want to use pg_stat_statements as profiler to switch on and switch off in controlled mode for the queries.The first step is replace int in query_hash and feature space hash on uint64. Additional description of the task in [1].

[1] https://confluence.postgrespro.ru/pages/viewpage.action\?pageId\=100073850