### PR TITLE
fix problem with test in unsupported.

### DIFF
--- a/expected/unsupported.out
+++ b/expected/unsupported.out
@@ -22,14 +22,15 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 (10 rows)
 
 -- Do not support having clauses for now.
+SELECT str FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 	SELECT * FROM t GROUP BY (x) HAVING x > 3;
-                  QUERY PLAN                   
+') AS str WHERE str NOT LIKE '%Memory Usage%';
+                      str                      
 -----------------------------------------------
  HashAggregate (actual rows=17 loops=1)
    AQO not used
    Group Key: x
-   Batches: 1  Memory Usage: 40kB
    ->  Seq Scan on t (actual rows=801 loops=1)
          AQO: rows=801, error=0%
          Filter: (x > 3)
@@ -37,6 +38,6 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(11 rows)
+(10 rows)
 
 DROP EXTENSION aqo;

--- a/sql/unsupported.sql
+++ b/sql/unsupported.sql
@@ -11,7 +11,9 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 ') AS str WHERE str NOT LIKE '%Memory Usage%';
 
 -- Do not support having clauses for now.
+SELECT str FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 	SELECT * FROM t GROUP BY (x) HAVING x > 3;
+') AS str WHERE str NOT LIKE '%Memory Usage%';
 
 DROP EXTENSION aqo;


### PR DESCRIPTION
Task:
Bugfix. Filter system-dependent strings in an explain output of
    'aqo_fdw' and 'unsupported' regression tests.