### PR TITLE
Disable materializing strategy of the planner in look-a-like tests.

### DIFF
--- a/expected/look_a_like.out
+++ b/expected/look_a_like.out
@@ -2,6 +2,7 @@ CREATE EXTENSION aqo;
 SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'on';
+SET enable_material = 'off';
 DROP TABLE IF EXISTS a,b CASCADE;
 NOTICE:  table "a" does not exist, skipping
 NOTICE:  table "b" does not exist, skipping
@@ -38,65 +39,60 @@ WHERE str NOT LIKE 'Query Identifier%';
  JOINS: 0
 (8 rows)
 
--- cardinality 100 in the first Seq Scan on a
 SELECT str AS result
 FROM expln('
 SELECT x FROM A,B WHERE x = 5 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%';
-                           result                           
-------------------------------------------------------------
+WHERE str NOT LIKE 'Query Identifier%'
+; -- Find cardinality for SCAN A(x=5) from a neighbour class, created by the
+                         result                         
+--------------------------------------------------------
  Nested Loop (actual rows=10000 loops=1)
    AQO not used
    Output: a.x
-   ->  Seq Scan on public.a (actual rows=100 loops=1)
+   ->  Seq Scan on public.b (actual rows=100 loops=1)
+         AQO not used
+         Output: b.y
+         Filter: (b.y = 5)
+         Rows Removed by Filter: 900
+   ->  Seq Scan on public.a (actual rows=100 loops=100)
          AQO: rows=100, error=0%
          Output: a.x
          Filter: (a.x = 5)
          Rows Removed by Filter: 900
-   ->  Materialize (actual rows=100 loops=100)
-         AQO not used
-         Output: b.y
-         ->  Seq Scan on public.b (actual rows=100 loops=1)
-               AQO not used
-               Output: b.y
-               Filter: (b.y = 5)
-               Rows Removed by Filter: 900
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(19 rows)
+(16 rows)
 
--- cardinality 100 in Nesteed Loop in the first Seq Scan on a
+-- query, executed above.
 SELECT str AS result
 FROM expln('
 SELECT x, sum(x) FROM A,B WHERE y = 5 AND A.x = B.y group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%';
-                              result                              
-------------------------------------------------------------------
+WHERE str NOT LIKE 'Query Identifier%'
+; -- Find the JOIN cardinality from a neighbour class.
+                            result                            
+--------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    AQO not used
    Output: a.x, sum(a.x)
    Group Key: a.x
    ->  Nested Loop (actual rows=10000 loops=1)
-         AQO not used
+         AQO: rows=10000, error=0%
          Output: a.x
          ->  Seq Scan on public.a (actual rows=100 loops=1)
                AQO: rows=100, error=0%
                Output: a.x
                Filter: (a.x = 5)
                Rows Removed by Filter: 900
-         ->  Materialize (actual rows=100 loops=100)
+         ->  Seq Scan on public.b (actual rows=100 loops=100)
                AQO: rows=100, error=0%
                Output: b.y
-               ->  Seq Scan on public.b (actual rows=100 loops=1)
-                     AQO: rows=100, error=0%
-                     Output: b.y
-                     Filter: (b.y = 5)
-                     Rows Removed by Filter: 900
+               Filter: (b.y = 5)
+               Rows Removed by Filter: 900
  Using aqo: true
  AQO mode: LEARN
  JOINS: 1
-(23 rows)
+(20 rows)
 
 -- cardinality 100 in the first Seq Scan on a
 SELECT str AS result
@@ -176,8 +172,8 @@ SELECT str AS result
 FROM expln('
 SELECT x FROM A,B where x < 10 and y > 10 group by(x);') AS str
 WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
-                             result                             
-----------------------------------------------------------------
+                          result                          
+----------------------------------------------------------
  HashAggregate (actual rows=0 loops=1)
    AQO not used
    Output: a.x
@@ -185,28 +181,29 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
    ->  Nested Loop (actual rows=0 loops=1)
          AQO not used
          Output: a.x
-         ->  Seq Scan on public.a (actual rows=1000 loops=1)
-               AQO: rows=1000, error=0%
+         ->  Seq Scan on public.b (actual rows=0 loops=1)
+               AQO not used
+               Output: b.y
+               Filter: (b.y > 10)
+               Rows Removed by Filter: 1000
+         ->  Seq Scan on public.a (never executed)
+               AQO: rows=1000
                Output: a.x
                Filter: (a.x < 10)
-         ->  Materialize (actual rows=0 loops=1000)
-               AQO not used
-               ->  Seq Scan on public.b (actual rows=0 loops=1)
-                     AQO not used
-                     Filter: (b.y > 10)
-                     Rows Removed by Filter: 1000
  Using aqo: true
  AQO mode: LEARN
  JOINS: 1
-(20 rows)
+(19 rows)
 
--- cardinality 1000 Hash Cond: (a.x = b.y) and 1 Seq Scan on b
--- this cardinality is wrong because we take it from bad neibours (previous query).
--- clause y > 10 give count of rows with the same clauses.
+--
+-- TODO:
+-- Not executed case. What could we do better here?
+--
 SELECT str AS result
 FROM expln('
 SELECT x,y FROM A,B WHERE x < 10 and y > 10 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%'
+;
                           result                          
 ----------------------------------------------------------
  Hash Join (actual rows=0 loops=1)
@@ -230,6 +227,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
  JOINS: 0
 (19 rows)
 
+RESET enable_material;
 DROP TABLE a,b CASCADE;
 SELECT true FROM aqo_reset();
  ?column? 


### PR DESCRIPTION
It is just because of difference in behaviour of different versions of PGPro executor. In some versions it can disable unnecessary repeatable scans of a materialize node.

XXX: Could we solve a problem by improvement of AQO logic?