### PR TITLE
Fix the bug with serialization machinery.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+ BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+
 jobs:
   build:
 
@@ -14,7 +17,7 @@ jobs:
     steps:
     - name: pg
       run: |
-        echo "Deploying to production server on branch $GITHUB_REF"
+        echo "Deploying to production server on branch" $BRANCH_NAME
         git config --global user.email "ci@postgrespro.ru"
         git config --global user.name "CI PgPro admin"
         git clone https://github.com/postgres/postgres.git pg
@@ -22,7 +25,7 @@ jobs:
         git checkout master
         ./configure --prefix=`pwd`/tmp_install CFLAGS="-O3"
         git clone https://github.com/postgrespro/aqo.git contrib/aqo
-        git -C contrib/aqo checkout $GITHUB_REF
+        git -C contrib/aqo checkout $BRANCH_NAME
         patch -p1 --no-backup-if-mismatch < contrib/aqo/aqo_master.patch
         make -j4 > /dev/null && make -j4 -C contrib > /dev/null
         env CLIENTS=50 THREADS=50 make -C contrib/aqo check

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ REGRESS =	aqo_disabled \
 			forced_stat_collection \
 			unsupported \
 			clean_aqo_data \
+			parallel_workers	\
 			plancache	\
 			statement_timeout \
 			temp_tables \

--- a/aqo_shared.c
+++ b/aqo_shared.c
@@ -77,11 +77,9 @@ reset_dsm_cache(void)
 
 	Assert(LWLockHeldByMeInMode(&aqo_state->lock, LW_EXCLUSIVE));
 
-	if (aqo_state->dsm_handler == DSM_HANDLE_INVALID)
+	if (aqo_state->dsm_handler == DSM_HANDLE_INVALID || !seg)
 		/* Fast path. No any cached data exists. */
 		return;
-
-	Assert(seg);
 
 	hdr = (dsm_seg_hdr *) dsm_segment_address(seg);
 	start = (char *) hdr + sizeof(dsm_seg_hdr);

--- a/expected/feature_subspace.out
+++ b/expected/feature_subspace.out
@@ -29,19 +29,17 @@ WHERE str NOT LIKE '%Memory%';
    AQO not used
    Merge Cond: (a.x = b.x)
    ->  Sort (actual rows=10 loops=1)
-         AQO not used
          Sort Key: a.x
          ->  Seq Scan on a (actual rows=10 loops=1)
                AQO not used
    ->  Sort (actual rows=11 loops=1)
-         AQO not used
          Sort Key: b.x
          ->  Seq Scan on b (actual rows=100 loops=1)
                AQO not used
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(16 rows)
+(14 rows)
 
 -- TODO: Using method of other classes neighbours we get a bad estimation.
 SELECT str AS result
@@ -56,13 +54,12 @@ WHERE str NOT LIKE '%Memory%';
    ->  Seq Scan on b (actual rows=100 loops=1)
          AQO: rows=100, error=0%
    ->  Hash (actual rows=10 loops=1)
-         AQO not used
          ->  Seq Scan on a (actual rows=10 loops=1)
                AQO: rows=10, error=0%
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(12 rows)
+(11 rows)
 
 -- Look into the reason: two JOINs from different classes have the same FSS.
 SELECT to_char(d1.targets[1], 'FM999.00') AS target FROM aqo_data d1

--- a/expected/look_a_like.out
+++ b/expected/look_a_like.out
@@ -148,7 +148,6 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
    Output: a.x, b.y
    Merge Cond: (a.x = b.y)
    ->  Sort (actual rows=1000 loops=1)
-         AQO not used
          Output: a.x
          Sort Key: a.x
          ->  Seq Scan on public.a (actual rows=1000 loops=1)
@@ -156,7 +155,6 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
                Output: a.x
                Filter: (a.x < 10)
    ->  Sort (actual rows=99901 loops=1)
-         AQO not used
          Output: b.y
          Sort Key: b.y
          ->  Seq Scan on public.b (actual rows=1000 loops=1)
@@ -165,7 +163,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(22 rows)
+(20 rows)
 
 -- cardinality 100 in Seq Scan on a and Seq Scan on b
 SELECT str AS result
@@ -215,7 +213,6 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%'
          Output: a.x
          Filter: (a.x < 10)
    ->  Hash (actual rows=0 loops=1)
-         AQO not used
          Output: b.y
          ->  Seq Scan on public.b (actual rows=0 loops=1)
                AQO: rows=1, error=100%
@@ -225,7 +222,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%'
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(19 rows)
+(18 rows)
 
 RESET enable_material;
 DROP TABLE a,b CASCADE;

--- a/expected/parallel_workers.out
+++ b/expected/parallel_workers.out
@@ -1,0 +1,125 @@
+-- Specifically test AQO machinery for queries uses partial paths and executed
+-- with parallel workers.
+CREATE EXTENSION aqo;
+-- Utility tool. Allow to filter system-dependent strings from explain output.
+CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
+BEGIN
+    RETURN QUERY
+        EXECUTE format('%s', query_string);
+    RETURN;
+END;
+$$ LANGUAGE PLPGSQL;
+SET aqo.join_threshold = 0;
+SET aqo.mode = 'learn';
+SET aqo.show_details = true;
+-- Be generous with a number parallel workers to test the machinery
+SET max_parallel_workers = 64;
+SET max_parallel_workers_per_gather = 64;
+-- Enforce usage of parallel workers
+SET parallel_setup_cost = 0.1;
+SET parallel_tuple_cost = 0.0001;
+CREATE TABLE t AS (
+  SELECT x AS id, repeat('a', 512) AS payload FROM generate_series(1, 1E5) AS x
+);
+ANALYZE t;
+-- Simple test. Check serialization machinery mostly.
+SELECT count(*) FROM t WHERE id % 100 = 0; -- Learning stage
+ count 
+-------
+  1000
+(1 row)
+
+SELECT str FROM expln('
+  EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+    SELECT count(*) FROM t WHERE id % 100 = 0;') AS str
+WHERE str NOT LIKE '%Worker%';
+                                str                                 
+--------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   AQO not used
+   ->  Gather (actual rows=3 loops=1)
+         AQO not used
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               AQO not used
+               ->  Parallel Seq Scan on t (actual rows=333 loops=3)
+                     AQO: rows=1000, error=0%
+                     Filter: ((id % '100'::numeric) = '0'::numeric)
+                     Rows Removed by Filter: 33000
+ Using aqo: true
+ AQO mode: LEARN
+ JOINS: 0
+(13 rows)
+
+-- More complex query just to provoke errors
+SELECT count(*) FROM
+  (SELECT id FROM t WHERE id % 100 = 0 GROUP BY (id)) AS q1,
+  (SELECT max(id) AS id, payload FROM t
+    WHERE id % 101 = 0 GROUP BY (payload)) AS q2
+WHERE q1.id = q2.id; -- Learning stage
+ count 
+-------
+     0
+(1 row)
+
+-- XXX: Why grouping prediction isn't working here?
+SELECT str FROM expln('
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT count(*) FROM
+  (SELECT id FROM t WHERE id % 100 = 0 GROUP BY (id)) AS q1,
+  (SELECT max(id) AS id, payload FROM t
+    WHERE id % 101 = 0 GROUP BY (payload)) AS q2
+WHERE q1.id = q2.id;') AS str
+WHERE str NOT LIKE '%Workers%' AND str NOT LIKE '%Sort Method%';
+                                               str                                                
+--------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   AQO not used
+   ->  Merge Join (actual rows=0 loops=1)
+         AQO not used
+         Merge Cond: (q2.id = t_1.id)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: q2.id
+               ->  Subquery Scan on q2 (actual rows=1 loops=1)
+                     AQO not used
+                     ->  Finalize GroupAggregate (actual rows=1 loops=1)
+                           AQO not used
+                           Group Key: t.payload
+                           ->  Gather Merge (actual rows=3 loops=1)
+                                 AQO not used
+                                 ->  Partial GroupAggregate (actual rows=1 loops=3)
+                                       AQO not used
+                                       Group Key: t.payload
+                                       ->  Sort (actual rows=330 loops=3)
+                                             AQO not used
+                                             Sort Key: t.payload
+                                             ->  Parallel Seq Scan on t (actual rows=330 loops=3)
+                                                   AQO: rows=991, error=0%
+                                                   Filter: ((id % '101'::numeric) = '0'::numeric)
+                                                   Rows Removed by Filter: 33003
+         ->  Group (actual rows=1000 loops=1)
+               AQO not used
+               Group Key: t_1.id
+               ->  Gather Merge (actual rows=1000 loops=1)
+                     AQO not used
+                     ->  Group (actual rows=333 loops=3)
+                           AQO not used
+                           Group Key: t_1.id
+                           ->  Sort (actual rows=333 loops=3)
+                                 AQO not used
+                                 Sort Key: t_1.id
+                                 ->  Parallel Seq Scan on t t_1 (actual rows=333 loops=3)
+                                       AQO: rows=991, error=-1%
+                                       Filter: ((id % '100'::numeric) = '0'::numeric)
+                                       Rows Removed by Filter: 33000
+ Using aqo: true
+ AQO mode: LEARN
+ JOINS: 1
+(42 rows)
+
+RESET parallel_tuple_cost;
+RESET parallel_setup_cost;
+RESET max_parallel_workers;
+RESET max_parallel_workers_per_gather;
+DROP TABLE t;
+DROP FUNCTION expln;
+DROP EXTENSION aqo;

--- a/expected/unsupported.out
+++ b/expected/unsupported.out
@@ -375,7 +375,6 @@ SELECT count(*) FROM
                              Filter: (x <> t_1.x)
                              Rows Removed by Filter: 50
          ->  Hash (actual rows=851 loops=1)
-               AQO not used
                ->  Seq Scan on t (actual rows=851 loops=1)
                      AQO: rows=851, error=0%
                      Filter: (((x % 3))::numeric < (SubPlan 1))
@@ -390,7 +389,7 @@ SELECT count(*) FROM
  Using aqo: true
  AQO mode: LEARN
  JOINS: 1
-(31 rows)
+(30 rows)
 
 -- Two identical subplans in a clause
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
@@ -543,12 +542,11 @@ WHERE str NOT LIKE '%Heap Blocks%' AND str NOT LIKE '%Query Identifier%';
          Filter: (t.x < 3)
          Rows Removed by Filter: 300
          ->  Bitmap Index Scan on ind2 (actual rows=350 loops=1)
-               AQO not used
                Index Cond: (mod(t.x, 3) = 1)
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(14 rows)
+(13 rows)
 
 -- Best choice is ...
 ANALYZE t;
@@ -577,7 +575,7 @@ ORDER BY (md5(query_text),error) DESC;
 -------+------------------------------------------------------------------------------------------------
  0.768 | SELECT count(*) FROM (SELECT count(*) FROM t1 GROUP BY (x,y)) AS q1;
  0.070 | SELECT count(*) FROM (SELECT * FROM t GROUP BY (x) HAVING x > 3) AS q1;
- 1.416 | SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
+ 0.000 | SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
  0.000 | SELECT * FROM                                                                                 +
        |         (SELECT * FROM t WHERE x < 0) AS t0                                                   +
        |                 JOIN                                                                          +

--- a/learn_cache.c
+++ b/learn_cache.c
@@ -293,7 +293,7 @@ lc_flush_data(void)
 		aqo_data_store(hdr->key.fs, hdr->key.fss, &data, reloids);
 
 		if (!hash_search(fss_htab, (void *) &hdr->key, HASH_REMOVE, NULL))
-			elog(ERROR, "[AQO] Flush: local ML cache is corrupted.");
+			elog(PANIC, "[AQO] Flush: local ML cache is corrupted.");
 	}
 
 	reset_dsm_cache();
@@ -323,7 +323,7 @@ lc_assign_hook(bool newval, void *extra)
 	while ((entry = (htab_entry *) hash_seq_search(&status)) != NULL)
 	{
 		if (!hash_search(fss_htab, (void *) &entry->key, HASH_REMOVE, NULL))
-			elog(ERROR, "[AQO] The local ML cache is corrupted.");
+			elog(PANIC, "[AQO] The local ML cache is corrupted.");
 	}
 	LWLockRelease(&aqo_state->lock);
 }

--- a/learn_cache.c
+++ b/learn_cache.c
@@ -127,6 +127,12 @@ lc_update_fss(uint64 fs, int fss, OkNNrdata *data, List *reloids)
 		}
 	}
 
+	/*
+	 * Kludge code. But we should rewrite this code because now all knowledge
+	 * base lives in non-transactional shared memory.
+	 */
+	ptr = (char *) hdr + sizeof(dsm_block_hdr) + (sizeof(double) * data->cols * aqo_K);
+
 	/* copy targets into DSM storage */
 	memcpy(ptr, data->targets, sizeof(double) * hdr->rows);
 	ptr += sizeof(double) * aqo_K;

--- a/path_utils.c
+++ b/path_utils.c
@@ -63,9 +63,7 @@ create_aqo_plan_node()
 
 /*
  * Extract an AQO node from the plan private field.
- * If no one node was found, return pointer to the default value or allocate new
- * node (with default value) according to 'create' field.
- * Can't return NULL value at all.
+ * If no one node was found, return pointer to the default value or return NULL.
  */
 AQOPlanNode *
 get_aqo_plan_node(Plan *plan, bool create)
@@ -90,7 +88,7 @@ get_aqo_plan_node(Plan *plan, bool create)
 	if (node == NULL)
 	{
 		if (!create)
-			return &DefaultAQOPlanNode;
+			return NULL;
 
 		node = create_aqo_plan_node();
 		plan->ext_nodes = lappend(plan->ext_nodes, node);
@@ -481,9 +479,14 @@ is_appropriate_path(Path *path)
 }
 
 /*
- * Converts path info into plan node for collecting it after query execution.
+ * Add AQO data into the plan node, if necessary.
+ *
+ * The necesssary case is when AQO is learning on this query, used for a
+ * prediction (and we will need the data to show prediction error at the end) or
+ * just to gather a plan statistics.
  * Don't switch here to any AQO-specific memory contexts, because we should
- * store AQO prediction in the same context, as the plan.
+ * store AQO prediction in the same context, as the plan. So, explicitly free
+ * all unneeded data.
  */
 void
 aqo_create_plan_hook(PlannerInfo *root, Path *src, Plan **dest)
@@ -495,7 +498,8 @@ aqo_create_plan_hook(PlannerInfo *root, Path *src, Plan **dest)
 	if (prev_create_plan_hook)
 		prev_create_plan_hook(root, src, dest);
 
-	if (!query_context.use_aqo && !query_context.learn_aqo)
+	if (!query_context.use_aqo && !query_context.learn_aqo &&
+		!query_context.collect_stat)
 		return;
 
 	is_join_path = (src->type == T_NestPath || src->type == T_MergePath ||
@@ -552,6 +556,11 @@ aqo_create_plan_hook(PlannerInfo *root, Path *src, Plan **dest)
 	}
 	else
 	{
+		/*
+		 * In the case of forced stat gathering AQO must store fss as well as
+		 * parallel divisor. Negative predicted cardinality field will be a sign
+		 * that it is not a prediction, just statistics.
+		 */
 		node->prediction = src->parent->predicted_cardinality;
 		node->fss = src->parent->fss_hash;
 	}
@@ -624,11 +633,6 @@ AQOnodeOut(struct StringInfoData *str, const struct ExtensibleNode *enode)
 {
 	AQOPlanNode *node = (AQOPlanNode *) enode;
 
-	node->had_path = false;
-	node->jointype = 0;
-	node->parallel_divisor = 1.0;
-	node->was_parametrized = false;
-
 	/* For Adaptive optimization DEBUG purposes */
 	WRITE_INT_FIELD(fss);
 	WRITE_FLOAT_FIELD(prediction, "%.0f");
@@ -676,10 +680,10 @@ AQOnodeRead(struct ExtensibleNode *enode)
 	const char	*token;
 	int			length;
 
-	READ_BOOL_FIELD(had_path);
-	READ_ENUM_FIELD(jointype, JoinType);
-	READ_FLOAT_FIELD(parallel_divisor);
-	READ_BOOL_FIELD(was_parametrized);
+	local_node->had_path = false;
+	local_node->jointype = 0;
+	local_node->parallel_divisor = 1.0;
+	local_node->was_parametrized = false;
 
 	local_node->rels = palloc0(sizeof(RelSortOut));
 	local_node->clauses = NIL;

--- a/postprocessing.c
+++ b/postprocessing.c
@@ -111,13 +111,14 @@ learn_agg_sample(aqo_obj_stat *ctx, RelSortOut *rels,
 	 * Learn 'not executed' nodes only once, if no one another knowledge exists
 	 * for current feature subspace.
 	 */
-	if (notExecuted && aqo_node->prediction > 0.)
+	if (notExecuted && aqo_node && aqo_node->prediction > 0.)
 		return;
 
 	target = log(learned);
 	child_fss = get_fss_for_object(rels->signatures, ctx->clauselist,
 								   NIL, NULL,NULL);
-	fss = get_grouped_exprs_hash(child_fss, aqo_node->grouping_exprs);
+	fss = get_grouped_exprs_hash(child_fss,
+								 aqo_node ? aqo_node->grouping_exprs : NIL);
 
 	/* Critical section */
 	atomic_fss_learn_step(fs, fss, data, NULL,
@@ -146,13 +147,13 @@ learn_sample(aqo_obj_stat *ctx, RelSortOut *rels,
 							 ctx->selectivities, &ncols, &features);
 
 	/* Only Agg nodes can have non-empty a grouping expressions list. */
-	Assert(!IsA(plan, Agg) || aqo_node->grouping_exprs != NIL);
+	Assert(!IsA(plan, Agg) || !aqo_node || aqo_node->grouping_exprs != NIL);
 
 	/*
 	 * Learn 'not executed' nodes only once, if no one another knowledge exists
 	 * for current feature subspace.
 	 */
-	if (notExecuted && aqo_node->prediction > 0)
+	if (notExecuted && aqo_node && aqo_node->prediction > 0)
 		return;
 
 	data = OkNNr_allocate(ncols);
@@ -303,18 +304,18 @@ learn_subplan_recurse(PlanState *p, aqo_obj_stat *ctx)
 
 static bool
 should_learn(PlanState *ps, AQOPlanNode *node, aqo_obj_stat *ctx,
-			 double predicted, double *nrows, double *rfactor)
+			 double predicted, double nrows, double *rfactor)
 {
 	if (ctx->isTimedOut)
 	{
-		if (ctx->learn && *nrows > predicted * 1.2)
+		if (ctx->learn && nrows > predicted * 1.2)
 		{
 			/* This node s*/
 			if (aqo_show_details)
 				elog(NOTICE,
 					 "[AQO] Learn on a plan node ("UINT64_FORMAT", %d), "
 					"predicted rows: %.0lf, updated prediction: %.0lf",
-					 query_context.query_hash, node->fss, predicted, *nrows);
+					 query_context.query_hash, node->fss, predicted, nrows);
 
 			*rfactor = RELIABILITY_MIN;
 			return true;
@@ -326,11 +327,11 @@ should_learn(PlanState *ps, AQOPlanNode *node, aqo_obj_stat *ctx,
 		{
 			/* This is much more reliable data. So we can correct our prediction. */
 			if (ctx->learn && aqo_show_details &&
-				fabs(*nrows - predicted) / predicted > 0.2)
+				fabs(nrows - predicted) / predicted > 0.2)
 				elog(NOTICE,
 					 "[AQO] Learn on a finished plan node ("UINT64_FORMAT", %d), "
 					 "predicted rows: %.0lf, updated prediction: %.0lf",
-					 query_context.query_hash, node->fss, predicted, *nrows);
+					 query_context.query_hash, node->fss, predicted, nrows);
 
 			*rfactor = 0.9 * (RELIABILITY_MAX - RELIABILITY_MIN);
 			return true;
@@ -371,7 +372,12 @@ learnOnPlanState(PlanState *p, void *context)
 		/* If something goes wrong, return quickly. */
 		return true;
 
-	aqo_node = get_aqo_plan_node(p->plan, false);
+	if ((aqo_node = get_aqo_plan_node(p->plan, false)) == NULL)
+		/*
+		 * Skip the node even for error calculation. It can be incorrect in the
+		 * case of parallel workers (parallel_divisor not known).
+		 */
+		goto end;
 
 	/*
 	 * Compute real value of rows, passed through this node. Summarize rows
@@ -477,7 +483,7 @@ learnOnPlanState(PlanState *p, void *context)
 
 	/*
 	 * Some nodes inserts after planning step (See T_Hash node type).
-	 * In this case we have'nt AQO prediction and fss record.
+	 * In this case we haven't AQO prediction and fss record.
 	 */
 	if (aqo_node->had_path)
 	{
@@ -507,7 +513,7 @@ learnOnPlanState(PlanState *p, void *context)
 
 				Assert(predicted >= 1. && learn_rows >= 1.);
 
-				if (should_learn(p, aqo_node, ctx, predicted, &learn_rows, &rfactor))
+				if (should_learn(p, aqo_node, ctx, predicted, learn_rows, &rfactor))
 				{
 					if (IsA(p, AggState))
 						learn_agg_sample(&SubplanCtx,
@@ -523,6 +529,7 @@ learnOnPlanState(PlanState *p, void *context)
 		}
 	}
 
+end:
 	ctx->clauselist = list_concat(ctx->clauselist, SubplanCtx.clauselist);
 	ctx->selectivities = list_concat(ctx->selectivities,
 													SubplanCtx.selectivities);
@@ -933,7 +940,8 @@ print_node_explain(ExplainState *es, PlanState *ps, Plan *plan)
 	if (IsQueryDisabled() || !plan || es->format != EXPLAIN_FORMAT_TEXT)
 		return;
 
-	aqo_node = get_aqo_plan_node(plan, false);
+	if ((aqo_node = get_aqo_plan_node(plan, false)) == NULL)
+		return;
 
 	if (!aqo_show_details || !ps)
 		goto explain_end;

--- a/postprocessing.c
+++ b/postprocessing.c
@@ -640,6 +640,13 @@ set_timeout_if_need(QueryDesc *queryDesc)
 {
 	TimestampTz	fin_time;
 
+	if (IsParallelWorker())
+		/*
+		 * AQO timeout should stop only main worker. Other workers would be
+		* terminated by a regular ERROR machinery.
+		*/
+		return false;
+
 	if (!get_timeout_active(STATEMENT_TIMEOUT) || !aqo_learn_statement_timeout)
 		return false;
 

--- a/preprocessing.c
+++ b/preprocessing.c
@@ -68,45 +68,6 @@
 #include "storage.h"
 
 
-const char *
-CleanQuerytext(const char *query, int *location, int *len)
-{
-	int			query_location = *location;
-	int			query_len = *len;
-
-	/* First apply starting offset, unless it's -1 (unknown). */
-	if (query_location >= 0)
-	{
-		Assert(query_location <= strlen(query));
-		query += query_location;
-		/* Length of 0 (or -1) means "rest of string" */
-		if (query_len <= 0)
-			query_len = strlen(query);
-		else
-			Assert(query_len <= strlen(query));
-	}
-	else
-	{
-		/* If query location is unknown, distrust query_len as well */
-		query_location = 0;
-		query_len = strlen(query);
-	}
-
-	/*
-	 * Discard leading and trailing whitespace, too.  Use scanner_isspace()
-	 * not libc's isspace(), because we want to match the lexer's behavior.
-	 */
-	while (query_len > 0 && scanner_isspace(query[0]))
-		query++, query_location++, query_len--;
-	while (query_len > 0 && scanner_isspace(query[query_len - 1]))
-		query_len--;
-
-	*location = query_location;
-	*len = query_len;
-
-	return query;
-}
-
 /* List of feature spaces, that are processing in this backend. */
 List *cur_classes = NIL;
 

--- a/sql/parallel_workers.sql
+++ b/sql/parallel_workers.sql
@@ -1,0 +1,61 @@
+-- Specifically test AQO machinery for queries uses partial paths and executed
+-- with parallel workers.
+
+CREATE EXTENSION aqo;
+
+-- Utility tool. Allow to filter system-dependent strings from explain output.
+CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
+BEGIN
+    RETURN QUERY
+        EXECUTE format('%s', query_string);
+    RETURN;
+END;
+$$ LANGUAGE PLPGSQL;
+
+SET aqo.join_threshold = 0;
+SET aqo.mode = 'learn';
+SET aqo.show_details = true;
+
+-- Be generous with a number parallel workers to test the machinery
+SET max_parallel_workers = 64;
+SET max_parallel_workers_per_gather = 64;
+-- Enforce usage of parallel workers
+SET parallel_setup_cost = 0.1;
+SET parallel_tuple_cost = 0.0001;
+
+CREATE TABLE t AS (
+  SELECT x AS id, repeat('a', 512) AS payload FROM generate_series(1, 1E5) AS x
+);
+ANALYZE t;
+
+-- Simple test. Check serialization machinery mostly.
+SELECT count(*) FROM t WHERE id % 100 = 0; -- Learning stage
+SELECT str FROM expln('
+  EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+    SELECT count(*) FROM t WHERE id % 100 = 0;') AS str
+WHERE str NOT LIKE '%Worker%';
+
+-- More complex query just to provoke errors
+SELECT count(*) FROM
+  (SELECT id FROM t WHERE id % 100 = 0 GROUP BY (id)) AS q1,
+  (SELECT max(id) AS id, payload FROM t
+    WHERE id % 101 = 0 GROUP BY (payload)) AS q2
+WHERE q1.id = q2.id; -- Learning stage
+-- XXX: Why grouping prediction isn't working here?
+SELECT str FROM expln('
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT count(*) FROM
+  (SELECT id FROM t WHERE id % 100 = 0 GROUP BY (id)) AS q1,
+  (SELECT max(id) AS id, payload FROM t
+    WHERE id % 101 = 0 GROUP BY (payload)) AS q2
+WHERE q1.id = q2.id;') AS str
+WHERE str NOT LIKE '%Workers%' AND str NOT LIKE '%Sort Method%';
+
+
+RESET parallel_tuple_cost;
+RESET parallel_setup_cost;
+RESET max_parallel_workers;
+RESET max_parallel_workers_per_gather;
+DROP TABLE t;
+DROP FUNCTION expln;
+DROP EXTENSION aqo;

--- a/storage.c
+++ b/storage.c
@@ -389,8 +389,8 @@ aqo_stat_reset(void)
 	hash_seq_init(&hash_seq, stat_htab);
 	while ((entry = hash_seq_search(&hash_seq)) != NULL)
 	{
-		if (hash_search(stat_htab, &entry->queryid, HASH_REMOVE, NULL) == NULL)
-			elog(ERROR, "[AQO] hash table corrupted");
+		if (!hash_search(stat_htab, &entry->queryid, HASH_REMOVE, NULL))
+			elog(PANIC, "[AQO] hash table corrupted");
 		num_remove++;
 	}
 	aqo_state->stat_changed = true;
@@ -1226,7 +1226,7 @@ _aqo_data_remove(data_key *key)
 		dsa_free(data_dsa, entry->data_dp);
 		entry->data_dp = InvalidDsaPointer;
 
-		if (hash_search(data_htab, key, HASH_REMOVE, NULL) == NULL)
+		if (!hash_search(data_htab, key, HASH_REMOVE, NULL))
 			elog(PANIC, "[AQO] Inconsistent data hash table");
 
 		aqo_state->data_changed = true;
@@ -1257,8 +1257,8 @@ aqo_qtexts_reset(void)
 
 		Assert(DsaPointerIsValid(entry->qtext_dp));
 		dsa_free(qtext_dsa, entry->qtext_dp);
-		if (hash_search(qtexts_htab, &entry->queryid, HASH_REMOVE, NULL) == NULL)
-			elog(ERROR, "[AQO] hash table corrupted");
+		if (!hash_search(qtexts_htab, &entry->queryid, HASH_REMOVE, NULL))
+			elog(PANIC, "[AQO] hash table corrupted");
 		num_remove++;
 	}
 	aqo_state->qtexts_changed = true;
@@ -1719,8 +1719,8 @@ _aqo_data_clean(uint64 fs)
 		Assert(DsaPointerIsValid(entry->data_dp));
 		dsa_free(data_dsa, entry->data_dp);
 		entry->data_dp = InvalidDsaPointer;
-		if (hash_search(data_htab, &entry->key, HASH_REMOVE, NULL) == NULL)
-			elog(ERROR, "[AQO] hash table corrupted");
+		if (!hash_search(data_htab, &entry->key, HASH_REMOVE, NULL))
+			elog(PANIC, "[AQO] hash table corrupted");
 		removed++;
 	}
 
@@ -1746,8 +1746,8 @@ aqo_data_reset(void)
 	{
 		Assert(DsaPointerIsValid(entry->data_dp));
 		dsa_free(data_dsa, entry->data_dp);
-		if (hash_search(data_htab, &entry->key, HASH_REMOVE, NULL) == NULL)
-			elog(ERROR, "[AQO] hash table corrupted");
+		if (!hash_search(data_htab, &entry->key, HASH_REMOVE, NULL))
+			elog(PANIC, "[AQO] hash table corrupted");
 		num_remove++;
 	}
 
@@ -1886,8 +1886,8 @@ aqo_queries_reset(void)
 			/* Don't remove default feature space */
 			continue;
 
-		if (hash_search(queries_htab, &entry->queryid, HASH_REMOVE, NULL) == NULL)
-			elog(ERROR, "[AQO] hash table corrupted");
+		if (!hash_search(queries_htab, &entry->queryid, HASH_REMOVE, NULL))
+			elog(PANIC, "[AQO] hash table corrupted");
 		num_remove++;
 	}
 


### PR DESCRIPTION
Change the AQO plan node behaviour: now we add such node also in the case when forced stat gathering option is enabled even in disabled mode.

Also:
1. Do not add AQO info into an explain AQO sentence if AQO node isn't existed for the node.
2. Exclude node which aren't predicted by AQO from a cardinality error computation.

Introduce 'parallel_workers' regression test.