### PR TITLE
Bugfix. AQOUtilityMemCtx is reset although some allocated data still …

### DIFF
--- a/aqo.c
+++ b/aqo.c
@@ -89,9 +89,6 @@ MemoryContext		AQOTopMemCtx = NULL;
 /* Is released at the end of transaction */
 MemoryContext		AQOCacheMemCtx = NULL;
 
-/* Should be released in-place, just after a huge calculation */
-MemoryContext		AQOUtilityMemCtx = NULL;
-
 /* Is released at the end of planning */
 MemoryContext 		AQOPredictMemCtx = NULL;
 
@@ -360,15 +357,7 @@ _PG_init(void)
 	AQOCacheMemCtx = AllocSetContextCreate(AQOTopMemCtx,
 											 "AQOCacheMemCtx",
 											 ALLOCSET_DEFAULT_SIZES);
-	/*
-	 * AQOUtilityMemoryContext containe short-lived information which
-	 * is appeared from having got clause, selectivity arrays and relid lists
-	 * while calculating hashes. It clean up inside calculated
-	 * function or immediately after her having completed.
-	 */
-	AQOUtilityMemCtx = AllocSetContextCreate(AQOTopMemCtx,
-											 "AQOUtilityMemoryContext",
-											 ALLOCSET_DEFAULT_SIZES);
+
 	/*
 	 * AQOPredictMemoryContext save necessary information for making predict of plan nodes
 	 * and clean up in the execution stage of query.

--- a/postprocessing.c
+++ b/postprocessing.c
@@ -180,16 +180,13 @@ restore_selectivities(List *clauselist, List *relidslist, JoinType join_type,
 	double		*cur_sel;
 	int			cur_hash;
 	int			cur_relid;
-	MemoryContext old_ctx_m;
 
 	parametrized_sel = was_parametrized && (list_length(relidslist) == 1);
 	if (parametrized_sel)
 	{
 		cur_relid = linitial_int(relidslist);
 
-		old_ctx_m = MemoryContextSwitchTo(AQOUtilityMemCtx);
 		get_eclasses(clauselist, &nargs, &args_hash, &eclass_hash);
-		MemoryContextSwitchTo(old_ctx_m);
 	}
 
 	foreach(l, clauselist)
@@ -222,11 +219,6 @@ restore_selectivities(List *clauselist, List *relidslist, JoinType join_type,
 
 		lst = lappend(lst, cur_sel);
 	}
-
-	if (parametrized_sel)
- 	{
-		MemoryContextReset(AQOUtilityMemCtx);
- 	}
 
 	return lst;
 }

--- a/preprocessing.c
+++ b/preprocessing.c
@@ -166,7 +166,8 @@ aqo_planner(Query *parse,
 			ParamListInfo boundParams)
 {
 	bool			query_is_stored = false;
-	MemoryContext oldctx;
+	MemoryContext	oldctx;
+
 	oldctx = MemoryContextSwitchTo(AQOPredictMemCtx);
 
 	 /*
@@ -195,15 +196,7 @@ aqo_planner(Query *parse,
 	}
 
 	selectivity_cache_clear();
-	MemoryContextSwitchTo(oldctx);
-
-	oldctx = MemoryContextSwitchTo(AQOUtilityMemCtx);
 	query_context.query_hash = get_query_hash(parse, query_string);
-	MemoryContextSwitchTo(oldctx);
-
-	MemoryContextReset(AQOUtilityMemCtx);
-
-	oldctx = MemoryContextSwitchTo(AQOPredictMemCtx);
 
 	/* By default, they should be equal */
 	query_context.fspace_hash = query_context.query_hash;

--- a/storage.c
+++ b/storage.c
@@ -2097,7 +2097,6 @@ cleanup_aqo_database(bool gentle, int *fs_num, int *fss_num)
 				for(i = 0; i < dentry->nrels; i++)
 				{
 					Oid reloid = ObjectIdGetDatum(*(Oid *)ptr);
-					MemoryContext oldctx = MemoryContextSwitchTo(AQOUtilityMemCtx);
 
 					if (!SearchSysCacheExists1(RELOID, reloid))
 						/* Remember this value */
@@ -2106,7 +2105,6 @@ cleanup_aqo_database(bool gentle, int *fs_num, int *fss_num)
 					else
 						actual_fss = list_append_unique_int(actual_fss,
 															dentry->key.fss);
-					MemoryContextSwitchTo(oldctx);
 
 					ptr += sizeof(Oid);
 				}
@@ -2156,8 +2154,6 @@ cleanup_aqo_database(bool gentle, int *fs_num, int *fss_num)
 			/* Query class preferences */
 			(*fs_num) += (int) _aqo_queries_remove(entry->queryid);
 		}
-
-		MemoryContextReset(AQOUtilityMemCtx);
 	}
 
 	/*


### PR DESCRIPTION
…in use.

Remove the AQOUtilityMemCtx memory context at all. It is used for too small operations. I don't buy that such operations can allocate so much memory that backend must free memory right after the end of operation to avoid OOM. I guess, prediction, planning and execution memory context set is good enough.