### PR TITLE
Fix failed test

### DIFF
--- a/aqo.conf
+++ b/aqo.conf
@@ -2,3 +2,4 @@ autovacuum = off
 shared_preload_libraries = 'postgres_fdw, aqo'
 max_parallel_maintenance_workers = 1 # switch off parallel workers because of unsteadiness
 aqo.wide_search = 'on'
+compute_query_id = 'regress'

--- a/expected/aqo_fdw.out
+++ b/expected/aqo_fdw.out
@@ -183,10 +183,13 @@ INSERT INTO main SELECT i, 'val_' || i FROM generate_series(1,100) i;
 INSERT INTO ref SELECT i, mod(i, 10) + 1, 'val_' || i FROM generate_series(1,1000) i;
 ANALYZE local_main_p0, local_main_p1, main_p2;
 ANALYZE local_ref_p0, local_ref_p1, ref_p2;
+SELECT str AS result
+FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT * from main AS a, ref AS b
-WHERE a.aid = b.aid AND b.bval like 'val%';
-                             QUERY PLAN                             
+WHERE a.aid = b.aid AND b.bval like ''val%''') AS str
+WHERE str NOT LIKE '%Memory%';
+                               result                               
 --------------------------------------------------------------------
  Append (actual rows=1000 loops=1)
    AQO not used
@@ -203,18 +206,20 @@ WHERE a.aid = b.aid AND b.bval like 'val%';
                AQO not used
                Filter: (bval ~~ 'val%'::text)
          ->  Hash (actual rows=38 loops=1)
-               Buckets: 1024  Batches: 1  Memory Usage: 10kB
                ->  Seq Scan on main_p2 a_3 (actual rows=38 loops=1)
                      AQO not used
  Using aqo: true
  AQO mode: LEARN
  JOINS: 1
-(21 rows)
+(20 rows)
 
+SELECT str AS result
+FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT * from main AS a, ref AS b
-WHERE a.aid = b.aid AND b.bval like 'val%';
-                             QUERY PLAN                             
+WHERE a.aid = b.aid AND b.bval like ''val%''') AS str
+WHERE str NOT LIKE '%Memory%';
+                               result                               
 --------------------------------------------------------------------
  Append (actual rows=1000 loops=1)
    AQO not used
@@ -231,13 +236,12 @@ WHERE a.aid = b.aid AND b.bval like 'val%';
                AQO: rows=300, error=0%
                Filter: (bval ~~ 'val%'::text)
          ->  Hash (actual rows=38 loops=1)
-               Buckets: 1024  Batches: 1  Memory Usage: 10kB
                ->  Seq Scan on main_p2 a_3 (actual rows=38 loops=1)
                      AQO: rows=38, error=0%
  Using aqo: true
  AQO mode: LEARN
  JOINS: 1
-(21 rows)
+(20 rows)
 
 DROP TABLE main, local_main_p0, local_main_p1;
 DROP TABLE ref, local_ref_p0, local_ref_p1;

--- a/expected/aqo_fdw.out
+++ b/expected/aqo_fdw.out
@@ -57,7 +57,7 @@ SELECT x FROM frgn;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
                             str                            
 -----------------------------------------------------------
  Foreign Scan on public.frgn (actual rows=1 loops=1)
@@ -72,7 +72,7 @@ SELECT str FROM expln('
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
                             str                            
 -----------------------------------------------------------
  Foreign Scan on public.frgn (actual rows=1 loops=1)
@@ -114,7 +114,7 @@ SELECT str FROM expln('
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x=b.x;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
                                                   str                                                   
 --------------------------------------------------------------------------------------------------------
  Foreign Scan (actual rows=1 loops=1)
@@ -259,7 +259,7 @@ SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
                                                   str                                                   
 --------------------------------------------------------------------------------------------------------
  Foreign Scan (actual rows=0 loops=1)

--- a/expected/gucs.out
+++ b/expected/gucs.out
@@ -10,6 +10,7 @@ $$ LANGUAGE PLPGSQL;
 SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = true;
+SET compute_query_id = 'auto';
 CREATE TABLE t(x int);
 INSERT INTO t (x) (SELECT * FROM generate_series(1, 100) AS gs);
 ANALYZE t;
@@ -20,33 +21,37 @@ SELECT true FROM aqo_reset(); -- Remember! DROP EXTENSION doesn't remove any AQO
 (1 row)
 
 -- Check AQO addons to explain (the only stable data)
-SELECT str FROM expln('
+SELECT regexp_replace(
+        str,'Query Identifier: -?\m\d+\M','Query Identifier: N','g') as str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
     SELECT x FROM t;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
                       str                       
 ------------------------------------------------
  Seq Scan on public.t (actual rows=100 loops=1)
    AQO not used
    Output: x
+ Query Identifier: N
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(6 rows)
+(7 rows)
 
-SELECT str FROM expln('
+SELECT regexp_replace(
+        str,'Query Identifier: -?\m\d+\M','Query Identifier: N','g') as str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
     SELECT x FROM t;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
                       str                       
 ------------------------------------------------
  Seq Scan on public.t (actual rows=100 loops=1)
    AQO: rows=100, error=0%
    Output: x
+ Query Identifier: N
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(6 rows)
+(7 rows)
 
 SET aqo.mode = 'disabled';
 -- Check existence of the interface functions.

--- a/expected/look_a_like.out
+++ b/expected/look_a_like.out
@@ -25,8 +25,7 @@ $$ LANGUAGE PLPGSQL;
 -- in the next queries with the same fss_hash
 SELECT str AS result
 FROM expln('
-SELECT x FROM A where x = 5;') AS str
-WHERE str NOT LIKE 'Query Identifier%';
+SELECT x FROM A where x = 5;') AS str;
                      result                     
 ------------------------------------------------
  Seq Scan on public.a (actual rows=100 loops=1)
@@ -42,7 +41,6 @@ WHERE str NOT LIKE 'Query Identifier%';
 SELECT str AS result
 FROM expln('
 SELECT x FROM A,B WHERE x = 5 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%'
 ; -- Find cardinality for SCAN A(x=5) from a neighbour class, created by the
                          result                         
 --------------------------------------------------------
@@ -68,7 +66,6 @@ WHERE str NOT LIKE 'Query Identifier%'
 SELECT str AS result
 FROM expln('
 SELECT x, sum(x) FROM A,B WHERE y = 5 AND A.x = B.y group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%'
 ; -- Find the JOIN cardinality from a neighbour class.
                             result                            
 --------------------------------------------------------------
@@ -97,8 +94,7 @@ WHERE str NOT LIKE 'Query Identifier%'
 -- cardinality 100 in the first Seq Scan on a
 SELECT str AS result
 FROM expln('
-SELECT x, sum(x) FROM A WHERE x = 5 group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%';
+SELECT x, sum(x) FROM A WHERE x = 5 group by(x);') AS str;
                         result                        
 ------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
@@ -120,7 +116,7 @@ WHERE str NOT LIKE 'Query Identifier%';
 SELECT str AS result
 FROM expln('
 SELECT x FROM A where x < 10 group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE '%Memory%';
                         result                         
 -------------------------------------------------------
  HashAggregate (actual rows=10 loops=1)
@@ -140,7 +136,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
 SELECT str AS result
 FROM expln('
 SELECT x,y FROM A,B WHERE x < 10 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE '%Memory%';
                            result                            
 -------------------------------------------------------------
  Merge Join (actual rows=100000 loops=1)
@@ -169,7 +165,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
 SELECT str AS result
 FROM expln('
 SELECT x FROM A,B where x < 10 and y > 10 group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE '%Memory%';
                           result                          
 ----------------------------------------------------------
  HashAggregate (actual rows=0 loops=1)
@@ -200,7 +196,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
 SELECT str AS result
 FROM expln('
 SELECT x,y FROM A,B WHERE x < 10 and y > 10 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%'
+WHERE str NOT LIKE '%Memory%'
 ;
                           result                          
 ----------------------------------------------------------

--- a/expected/unsupported.out
+++ b/expected/unsupported.out
@@ -530,7 +530,7 @@ SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, SUMMARY OFF, TIMING OFF)
     SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1') AS str
-WHERE str NOT LIKE '%Heap Blocks%' AND str NOT LIKE '%Query Identifier%';
+WHERE str NOT LIKE '%Heap Blocks%';
                                str                               
 -----------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)

--- a/sql/aqo_fdw.sql
+++ b/sql/aqo_fdw.sql
@@ -114,13 +114,19 @@ INSERT INTO ref SELECT i, mod(i, 10) + 1, 'val_' || i FROM generate_series(1,100
 ANALYZE local_main_p0, local_main_p1, main_p2;
 ANALYZE local_ref_p0, local_ref_p1, ref_p2;
 
+SELECT str AS result
+FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT * from main AS a, ref AS b
-WHERE a.aid = b.aid AND b.bval like 'val%';
+WHERE a.aid = b.aid AND b.bval like ''val%''') AS str
+WHERE str NOT LIKE '%Memory%';
 
+SELECT str AS result
+FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT * from main AS a, ref AS b
-WHERE a.aid = b.aid AND b.bval like 'val%';
+WHERE a.aid = b.aid AND b.bval like ''val%''') AS str
+WHERE str NOT LIKE '%Memory%';
 
 DROP TABLE main, local_main_p0, local_main_p1;
 DROP TABLE ref, local_ref_p0, local_ref_p1;

--- a/sql/aqo_fdw.sql
+++ b/sql/aqo_fdw.sql
@@ -47,11 +47,11 @@ SELECT x FROM frgn;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT x FROM frgn WHERE x < -10; -- AQO ignores constants
 
@@ -65,7 +65,7 @@ SELECT str FROM expln('
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x=b.x;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
 
 CREATE TABLE local_a(aid int primary key, aval text);
 CREATE TABLE local_b(bid int primary key, aid int references local_a(aid), bval text);
@@ -133,7 +133,7 @@ SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
 
 DROP EXTENSION aqo CASCADE;
 DROP EXTENSION postgres_fdw CASCADE;

--- a/sql/gucs.sql
+++ b/sql/gucs.sql
@@ -12,6 +12,7 @@ $$ LANGUAGE PLPGSQL;
 SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = true;
+SET compute_query_id = 'auto';
 
 CREATE TABLE t(x int);
 INSERT INTO t (x) (SELECT * FROM generate_series(1, 100) AS gs);
@@ -19,14 +20,16 @@ ANALYZE t;
 
 SELECT true FROM aqo_reset(); -- Remember! DROP EXTENSION doesn't remove any AQO data gathered.
 -- Check AQO addons to explain (the only stable data)
-SELECT str FROM expln('
+SELECT regexp_replace(
+        str,'Query Identifier: -?\m\d+\M','Query Identifier: N','g') as str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
     SELECT x FROM t;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
-SELECT str FROM expln('
+') AS str;
+SELECT regexp_replace(
+        str,'Query Identifier: -?\m\d+\M','Query Identifier: N','g') as str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
     SELECT x FROM t;
-') AS str WHERE str NOT LIKE '%Query Identifier%';
+') AS str;
 SET aqo.mode = 'disabled';
 
 -- Check existence of the interface functions.

--- a/sql/look_a_like.sql
+++ b/sql/look_a_like.sql
@@ -28,45 +28,41 @@ $$ LANGUAGE PLPGSQL;
 -- in the next queries with the same fss_hash
 SELECT str AS result
 FROM expln('
-SELECT x FROM A where x = 5;') AS str
-WHERE str NOT LIKE 'Query Identifier%';
+SELECT x FROM A where x = 5;') AS str;
 
 SELECT str AS result
 FROM expln('
 SELECT x FROM A,B WHERE x = 5 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%'
 ; -- Find cardinality for SCAN A(x=5) from a neighbour class, created by the
 -- query, executed above.
 
 SELECT str AS result
 FROM expln('
 SELECT x, sum(x) FROM A,B WHERE y = 5 AND A.x = B.y group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%'
 ; -- Find the JOIN cardinality from a neighbour class.
 
 -- cardinality 100 in the first Seq Scan on a
 SELECT str AS result
 FROM expln('
-SELECT x, sum(x) FROM A WHERE x = 5 group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%';
+SELECT x, sum(x) FROM A WHERE x = 5 group by(x);') AS str;
 
 -- no one predicted rows. we use knowledge cardinalities of the query
 -- in the next queries with the same fss_hash
 SELECT str AS result
 FROM expln('
 SELECT x FROM A where x < 10 group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE '%Memory%';
 -- cardinality 1000 in Seq Scan on a
 SELECT str AS result
 FROM expln('
 SELECT x,y FROM A,B WHERE x < 10 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE '%Memory%';
 
 -- cardinality 100 in Seq Scan on a and Seq Scan on b
 SELECT str AS result
 FROM expln('
 SELECT x FROM A,B where x < 10 and y > 10 group by(x);') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
+WHERE str NOT LIKE '%Memory%';
 
 --
 -- TODO:
@@ -75,7 +71,7 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%';
 SELECT str AS result
 FROM expln('
 SELECT x,y FROM A,B WHERE x < 10 and y > 10 AND A.x = B.y;') AS str
-WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%'
+WHERE str NOT LIKE '%Memory%'
 ;
 
 RESET enable_material;

--- a/sql/unsupported.sql
+++ b/sql/unsupported.sql
@@ -165,7 +165,7 @@ SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, SUMMARY OFF, TIMING OFF)
     SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1') AS str
-WHERE str NOT LIKE '%Heap Blocks%' AND str NOT LIKE '%Query Identifier%';
+WHERE str NOT LIKE '%Heap Blocks%';
 
 -- Best choice is ...
 ANALYZE t;


### PR DESCRIPTION
It turned out that vanilla regression tests failed using aqo_pg 14.patch in this version. This problem is related to running the Enable Query Id function in _PG_init(). We cannot remove the call to this function due to the launch of assert when query_id_enabled is disabled in query jumble. A similar function to enable query_id_enabled (enable query id) is used in pg_stat_statements, but the Makefile contains the addition of NO_INSTALL CHECK = 1 and does not run regression tests by default.
So, I have prepared changes for fix it.