### PR TITLE
Partial revert "Change names of interface functions for better usage"

### DIFF
--- a/aqo--1.4--1.5.sql
+++ b/aqo--1.4--1.5.sql
@@ -77,14 +77,14 @@ CREATE VIEW aqo_queries AS SELECT * FROM aqo_queries();
 /* UI functions */
 
 
-CREATE FUNCTION aqo_enable_class(queryid bigint)
+CREATE FUNCTION aqo_enable_query(queryid bigint)
 RETURNS void
-AS 'MODULE_PATHNAME', 'aqo_enable_class'
+AS 'MODULE_PATHNAME', 'aqo_enable_query'
 LANGUAGE C STRICT VOLATILE;
 
-CREATE FUNCTION aqo_disable_class(queryid bigint)
+CREATE FUNCTION aqo_disable_query(queryid bigint)
 RETURNS void
-AS 'MODULE_PATHNAME', 'aqo_disable_class'
+AS 'MODULE_PATHNAME', 'aqo_enable_query'
 LANGUAGE C STRICT VOLATILE;
 
 CREATE FUNCTION aqo_queries_update(

--- a/expected/aqo_CVE-2020-14350.out
+++ b/expected/aqo_CVE-2020-14350.out
@@ -116,7 +116,7 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_enable_class(hash bigint)
+CREATE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -125,9 +125,9 @@ $$ LANGUAGE plpgsql;
 RESET ROLE;
 -- Test result (error expected)
 CREATE EXTENSION aqo;
-ERROR:  function "aqo_enable_class" already exists with same argument types
+ERROR:  function "aqo_enable_query" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_enable_class(hash bigint)
+CREATE OR REPLACE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -135,8 +135,8 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
-SELECT aqo_enable_class(42);
- aqo_enable_class 
+SELECT aqo_enable_query(42);
+ aqo_enable_query 
 ------------------
  
 (1 row)
@@ -149,7 +149,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_enable_class(bigint);
+DROP FUNCTION aqo_enable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 4
@@ -162,7 +162,7 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_disable_class(hash bigint)
+CREATE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -171,9 +171,9 @@ $$ LANGUAGE plpgsql;
 RESET ROLE;
 -- Test result (error expected)
 CREATE EXTENSION aqo;
-ERROR:  function "aqo_disable_class" already exists with same argument types
+ERROR:  function "aqo_disable_query" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_disable_class(hash bigint)
+CREATE OR REPLACE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -181,8 +181,8 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
-SELECT aqo_disable_class(42);
- aqo_disable_class 
+SELECT aqo_disable_query(42);
+ aqo_disable_query 
 -------------------
  
 (1 row)
@@ -195,7 +195,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_disable_class(bigint);
+DROP FUNCTION aqo_disable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 5

--- a/expected/relocatable.out
+++ b/expected/relocatable.out
@@ -80,9 +80,9 @@ ORDER BY (md5(query_text))
 /*
  * Below, we should check each UI function
  */
-SELECT aqo_disable_class(id) FROM (
+SELECT aqo_disable_query(id) FROM (
   SELECT queryid AS id FROM aqo_queries WHERE queryid <> 0) AS q1;
- aqo_disable_class 
+ aqo_disable_query 
 -------------------
  
  
@@ -93,13 +93,13 @@ ORDER BY (learn_aqo, use_aqo, auto_tuning);
  learn_aqo | use_aqo | auto_tuning 
 -----------+---------+-------------
  f         | f       | f
- f         | f       | f
- f         | f       | f
+ t         | t       | f
+ t         | t       | f
 (3 rows)
 
-SELECT aqo_enable_class(id) FROM (
+SELECT aqo_enable_query(id) FROM (
   SELECT queryid AS id FROM aqo_queries WHERE queryid <> 0) AS q1;
- aqo_enable_class 
+ aqo_enable_query 
 ------------------
  
  

--- a/sql/aqo_CVE-2020-14350.sql
+++ b/sql/aqo_CVE-2020-14350.sql
@@ -103,7 +103,7 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_enable_class(hash bigint)
+CREATE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -115,7 +115,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_enable_class(hash bigint)
+CREATE OR REPLACE FUNCTION aqo_enable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -124,13 +124,13 @@ END
 $$ LANGUAGE plpgsql;
 
 RESET ROLE;
-SELECT aqo_enable_class(42);
+SELECT aqo_enable_query(42);
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_enable_class(bigint);
+DROP FUNCTION aqo_enable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 4
@@ -140,7 +140,7 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_disable_class(hash bigint)
+CREATE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -152,7 +152,7 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_disable_class(hash bigint)
+CREATE OR REPLACE FUNCTION aqo_disable_query(hash bigint)
 RETURNS VOID
 AS $$
 BEGIN
@@ -161,13 +161,13 @@ END
 $$ LANGUAGE plpgsql;
 
 RESET ROLE;
-SELECT aqo_disable_class(42);
+SELECT aqo_disable_query(42);
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_disable_class(bigint);
+DROP FUNCTION aqo_disable_query(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 5

--- a/sql/relocatable.sql
+++ b/sql/relocatable.sql
@@ -39,11 +39,11 @@ ORDER BY (md5(query_text))
 /*
  * Below, we should check each UI function
  */
-SELECT aqo_disable_class(id) FROM (
+SELECT aqo_disable_query(id) FROM (
   SELECT queryid AS id FROM aqo_queries WHERE queryid <> 0) AS q1;
 SELECT learn_aqo, use_aqo, auto_tuning FROM test.aqo_queries
 ORDER BY (learn_aqo, use_aqo, auto_tuning);
-SELECT aqo_enable_class(id) FROM (
+SELECT aqo_enable_query(id) FROM (
   SELECT queryid AS id FROM aqo_queries WHERE queryid <> 0) AS q1;
 SELECT learn_aqo, use_aqo, auto_tuning FROM test.aqo_queries
 ORDER BY (learn_aqo, use_aqo, auto_tuning);

--- a/storage.c
+++ b/storage.c
@@ -96,8 +96,8 @@ PG_FUNCTION_INFO_V1(aqo_query_stat);
 PG_FUNCTION_INFO_V1(aqo_query_texts);
 PG_FUNCTION_INFO_V1(aqo_data);
 PG_FUNCTION_INFO_V1(aqo_queries);
-PG_FUNCTION_INFO_V1(aqo_enable_class);
-PG_FUNCTION_INFO_V1(aqo_disable_class);
+PG_FUNCTION_INFO_V1(aqo_enable_query);
+PG_FUNCTION_INFO_V1(aqo_disable_query);
 PG_FUNCTION_INFO_V1(aqo_queries_update);
 PG_FUNCTION_INFO_V1(aqo_reset);
 PG_FUNCTION_INFO_V1(aqo_cleanup);
@@ -1903,7 +1903,7 @@ aqo_queries_reset(void)
 }
 
 Datum
-aqo_enable_class(PG_FUNCTION_ARGS)
+aqo_enable_query(PG_FUNCTION_ARGS)
 {
 	uint64			queryid = (uint64) PG_GETARG_INT64(0);
 	QueriesEntry   *entry;
@@ -1934,7 +1934,7 @@ aqo_enable_class(PG_FUNCTION_ARGS)
 }
 
 Datum
-aqo_disable_class(PG_FUNCTION_ARGS)
+aqo_disable_query(PG_FUNCTION_ARGS)
 {
 	uint64			queryid = (uint64) PG_GETARG_INT64(0);
 	QueriesEntry   *entry;


### PR DESCRIPTION
This reverts commit f097d8b3c428d909a1f7da7977a5bef8dfaa2f7b except for changes to the function invalidate_deactivated_queries_cache.