### PR TITLE
Revert last changes in aqo--1.4--1.5.sql

### DIFF
--- a/aqo--1.4--1.5.sql
+++ b/aqo--1.4--1.5.sql
@@ -19,7 +19,6 @@ DROP TABLE public.aqo_data CASCADE;
 DROP TABLE public.aqo_queries CASCADE;
 DROP TABLE public.aqo_query_texts CASCADE;
 DROP TABLE public.aqo_query_stat CASCADE;
-DROP FUNCTION invalidate_deactivated_queries_cache;
 
 
 /*
@@ -145,7 +144,6 @@ COMMENT ON FUNCTION aqo_drop_class(bigint) IS
 -- Returns number of deleted rows from aqo_queries and aqo_data tables.
 --
 CREATE OR REPLACE FUNCTION aqo_cleanup(OUT nfs integer, OUT nfss integer)
-RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'aqo_cleanup'
 LANGUAGE C STRICT VOLATILE;
 COMMENT ON FUNCTION aqo_cleanup() IS

--- a/expected/gucs.out
+++ b/expected/gucs.out
@@ -93,7 +93,7 @@ SELECT obj_description('aqo_reset'::regproc::oid);
                                  List of functions
  Schema |    Name     | Result data type |        Argument data types        | Type 
 --------+-------------+------------------+-----------------------------------+------
- public | aqo_cleanup | SETOF record     | OUT nfs integer, OUT nfss integer | func
+ public | aqo_cleanup | record           | OUT nfs integer, OUT nfss integer | func
 (1 row)
 
 \df aqo_reset


### PR DESCRIPTION
They can only be made in the next version of aqo. Because the current one is already released.