### PR TITLE
[PGPRO-7366] add function which shows memory usage

### DIFF
--- a/aqo--1.5--1.6.sql
+++ b/aqo--1.5--1.6.sql
@@ -98,3 +98,19 @@ AS 'MODULE_PATHNAME', 'aqo_queries'
 LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
 
 CREATE VIEW aqo_queries AS SELECT * FROM aqo_queries();
+
+CREATE FUNCTION aqo_memory_usage(
+  OUT name text,
+  OUT allocated_size int,
+  OUT used_size int
+)
+RETURNS SETOF record
+AS $$
+  SELECT name, total_bytes, used_bytes FROM pg_backend_memory_contexts
+  WHERE name LIKE 'AQO%'
+  UNION
+  SELECT name, allocated_size, size FROM pg_shmem_allocations
+  WHERE name LIKE 'AQO%';
+$$ LANGUAGE SQL;
+COMMENT ON FUNCTION aqo_memory_usage() IS
+'Show allocated sizes and used sizes of aqo`s memory contexts and hash tables';

--- a/t/001_pgbench.pl
+++ b/t/001_pgbench.pl
@@ -160,6 +160,9 @@ $res = $node->safe_psql('postgres',
 						WHERE v.exec_time > 0.");
 is($res, 3);
 
+$res = $node->safe_psql('postgres', "SELECT * FROM aqo_memory_usage() AS t1");
+note("MEMORY:\n$res\n");
+
 # ##############################################################################
 #
 # pgbench on a database with AQO in 'learn' mode.
@@ -183,6 +186,9 @@ $node->safe_psql('postgres', "SELECT pg_reload_conf()");
 $node->command_ok([ 'pgbench', '-t',
 					"$TRANSACTIONS", '-c', "$CLIENTS", '-j', "$THREADS" ],
 					'pgbench in frozen mode');
+
+$res = $node->safe_psql('postgres', "SELECT * FROM aqo_memory_usage() AS t1");
+note("MEMORY:\n$res\n");
 
 # ##############################################################################
 #
@@ -298,6 +304,9 @@ is($new_fs_samples_count == $fs_samples_count - $pgb_fs_samples_count, 1,
 	'Total number of samples in aqo_query_texts');
 is($new_stat_count == $stat_count - $pgb_stat_count, 1,
 	'Total number of samples in aqo_query_stat');
+
+$res = $node->safe_psql('postgres', "SELECT * FROM aqo_memory_usage() AS t1");
+note("MEMORY:\n$res\n");
 
 # ##############################################################################
 #


### PR DESCRIPTION
function memctx_htab_sizes outputs allocated sizes and used sizes of aqo's memory contexts and hash tables