### PR TITLE
Rewriting the statement_timeout test to spend less time on its execut…

### DIFF
--- a/expected/statement_timeout.out
+++ b/expected/statement_timeout.out
@@ -17,7 +17,7 @@ BEGIN
         END IF;
     END LOOP;
 END; $$;
-CREATE TABLE t AS SELECT * FROM generate_series(1,100) AS x;
+CREATE TABLE t AS SELECT * FROM generate_series(1,50) AS x;
 ANALYZE t;
 DELETE FROM t WHERE x > 5; -- Force optimizer to make overestimated prediction.
 CREATE EXTENSION IF NOT EXISTS aqo;
@@ -25,30 +25,30 @@ SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'off';
 SET aqo.learn_statement_timeout = 'on';
-SET statement_timeout = 800; -- [0.8s]
-SELECT *, pg_sleep(1) FROM t;
+SET statement_timeout = 100; -- [0.1s]
+SELECT *, pg_sleep(0.1) FROM t;
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;'); -- haven't any partial data
  check_estimated_rows 
 ----------------------
-                  100
+                   50
 (1 row)
 
 -- Don't learn because running node has smaller cardinality than an optimizer prediction
-SET statement_timeout = 3500;
-SELECT *, pg_sleep(1) FROM t;
+SET statement_timeout = 400;
+SELECT *, pg_sleep(0.1) FROM t;
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
  check_estimated_rows 
 ----------------------
-                  100
+                   50
 (1 row)
 
 -- We have a real learning data.
-SET statement_timeout = 10000;
-SELECT *, pg_sleep(1) FROM t;
+SET statement_timeout = 8000;
+SELECT *, pg_sleep(0.1) FROM t;
  x | pg_sleep 
 ---+----------
  1 | 
@@ -74,8 +74,8 @@ SELECT 1 FROM aqo_reset();
         1
 (1 row)
 
-SET statement_timeout = 800;
-SELECT *, pg_sleep(1) FROM t; -- Not learned
+SET statement_timeout = 100;
+SELECT *, pg_sleep(0.1) FROM t; -- Not learned
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
@@ -84,18 +84,18 @@ SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
                     2
 (1 row)
 
-SET statement_timeout = 3500;
-SELECT *, pg_sleep(1) FROM t; -- Learn!
+SET statement_timeout = 500;
+SELECT *, pg_sleep(0.1) FROM t; -- Learn!
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
  check_estimated_rows 
 ----------------------
-                    3
+                    2
 (1 row)
 
-SET statement_timeout = 5500;
-SELECT *, pg_sleep(1) FROM t; -- Get reliable data
+SET statement_timeout = 800;
+SELECT *, pg_sleep(0.1) FROM t; -- Get reliable data
  x | pg_sleep 
 ---+----------
  1 | 

--- a/sql/statement_timeout.sql
+++ b/sql/statement_timeout.sql
@@ -18,7 +18,7 @@ BEGIN
     END LOOP;
 END; $$;
 
-CREATE TABLE t AS SELECT * FROM generate_series(1,100) AS x;
+CREATE TABLE t AS SELECT * FROM generate_series(1,50) AS x;
 ANALYZE t;
 DELETE FROM t WHERE x > 5; -- Force optimizer to make overestimated prediction.
 
@@ -28,18 +28,18 @@ SET aqo.mode = 'learn';
 SET aqo.show_details = 'off';
 SET aqo.learn_statement_timeout = 'on';
 
-SET statement_timeout = 800; -- [0.8s]
-SELECT *, pg_sleep(1) FROM t;
+SET statement_timeout = 100; -- [0.1s]
+SELECT *, pg_sleep(0.1) FROM t;
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;'); -- haven't any partial data
 
 -- Don't learn because running node has smaller cardinality than an optimizer prediction
-SET statement_timeout = 3500;
-SELECT *, pg_sleep(1) FROM t;
+SET statement_timeout = 400;
+SELECT *, pg_sleep(0.1) FROM t;
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
 
 -- We have a real learning data.
-SET statement_timeout = 10000;
-SELECT *, pg_sleep(1) FROM t;
+SET statement_timeout = 8000;
+SELECT *, pg_sleep(0.1) FROM t;
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
 
 -- Force to make an underestimated prediction
@@ -48,16 +48,16 @@ ANALYZE t;
 INSERT INTO t (x) (SELECT * FROM generate_series(3,5) AS x);
 SELECT 1 FROM aqo_reset();
 
+SET statement_timeout = 100;
+SELECT *, pg_sleep(0.1) FROM t; -- Not learned
+SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+
+SET statement_timeout = 500;
+SELECT *, pg_sleep(0.1) FROM t; -- Learn!
+SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+
 SET statement_timeout = 800;
-SELECT *, pg_sleep(1) FROM t; -- Not learned
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
-
-SET statement_timeout = 3500;
-SELECT *, pg_sleep(1) FROM t; -- Learn!
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
-
-SET statement_timeout = 5500;
-SELECT *, pg_sleep(1) FROM t; -- Get reliable data
+SELECT *, pg_sleep(0.1) FROM t; -- Get reliable data
 SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
 
 -- Interrupted query should immediately appear in aqo_data


### PR DESCRIPTION
…ion. unfortunately,

this does not completely solve the problem of the imbalance between the cost of resources expended (namely, the duration of the test) and its usefulness, since its results are ignored.
We cannot completely exclude the test from the test, since it is necessary to know about cases of test failure during the further development of the extension.