### PR TITLE
One more step to improve AQO regression tests stability.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ TAP_TESTS = 1
 REGRESS = aqo_dummy_test
 REGRESS_OPTS = --schedule=$(srcdir)/regress_schedule
 
+# Set default values of some gucs to be stable on custom settings during
+# a kind of installcheck
+PGOPTIONS = --aqo.force_collect_stat=off --max_parallel_maintenance_workers=1 \
+	--aqo.join_threshold=0 --max_parallel_workers_per_gather=1
+export PGOPTIONS
+
 fdw_srcdir = $(top_srcdir)/contrib/postgres_fdw
 stat_srcdir = $(top_srcdir)/contrib/pg_stat_statements
 PG_CPPFLAGS += -I$(libpq_srcdir) -I$(fdw_srcdir) -I$(stat_srcdir)

--- a/aqo.conf
+++ b/aqo.conf
@@ -1,5 +1,2 @@
 autovacuum = off
 shared_preload_libraries = 'postgres_fdw, aqo'
-max_parallel_maintenance_workers = 1 # switch off parallel workers because of unsteadiness
-aqo.wide_search = 'on'
-

--- a/expected/aqo_controlled.out
+++ b/expected/aqo_controlled.out
@@ -1,3 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 CREATE TABLE aqo_test0(a int, b int, c int, d int);
 WITH RECURSIVE t(a, b, c, d)
 AS (
@@ -25,8 +32,6 @@ AS (
 ) INSERT INTO aqo_test2 (SELECT * FROM t);
 CREATE INDEX aqo_test2_idx_a ON aqo_test2 (a);
 ANALYZE aqo_test2;
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'controlled';
 EXPLAIN (COSTS FALSE)
 SELECT * FROM aqo_test0
@@ -199,11 +204,12 @@ WHERE t1.a = t2.b AND t2.a = t3.b;
 
 SELECT count(*) FROM
 	(SELECT queryid AS id FROM aqo_queries) AS q1,
-	LATERAL aqo_queries_update(q1.id, NULL, NULL, true, NULL)
+	LATERAL aqo_queries_update(q1.id, NULL, NULL, true, NULL) AS ret
+WHERE NOT ret
 ; -- set use = true
  count 
 -------
-    12
+     1
 (1 row)
 
 EXPLAIN (COSTS FALSE)
@@ -311,11 +317,4 @@ DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
 DROP INDEX aqo_test2_idx_a;
 DROP TABLE aqo_test2;
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/aqo_disabled.out
+++ b/expected/aqo_disabled.out
@@ -1,3 +1,12 @@
+-- Create the extension. Drop all lumps which could survive from
+-- previous pass (repeated installcheck as an example).
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 CREATE TABLE aqo_test0(a int, b int, c int, d int);
 WITH RECURSIVE t(a, b, c, d)
 AS (
@@ -16,8 +25,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'controlled';
 CREATE TABLE tmp1 AS SELECT * FROM aqo_test0
 WHERE a < 3 AND b < 3 AND c < 3 AND d < 3;
@@ -151,11 +158,12 @@ SELECT count(*) FROM aqo_queries WHERE queryid <> fs; -- Should be zero
 SET aqo.mode = 'controlled';
 SELECT count(*) FROM
 	(SELECT queryid AS id FROM aqo_queries) AS q1,
-	LATERAL aqo_queries_update(q1.id, NULL, true, true, false)
+	LATERAL aqo_queries_update(q1.id, NULL, true, true, false) AS ret
+WHERE NOT ret
 ; -- Enable all disabled query classes
  count 
 -------
-     5
+     1
 (1 row)
 
 EXPLAIN SELECT * FROM aqo_test0
@@ -223,15 +231,8 @@ SELECT count(*) FROM aqo_queries WHERE queryid <> fs; -- Should be zero
      0
 (1 row)
 
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
-DROP EXTENSION aqo;
 DROP INDEX aqo_test0_idx_a;
 DROP TABLE aqo_test0;
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
+DROP EXTENSION aqo;

--- a/expected/aqo_fdw.out
+++ b/expected/aqo_fdw.out
@@ -3,12 +3,17 @@
 -- JOIN push-down (check push of baserestrictinfo and joininfo)
 -- Aggregate push-down
 -- Push-down of groupings with HAVING clause.
-CREATE EXTENSION aqo;
-CREATE EXTENSION postgres_fdw;
+CREATE EXTENSION IF NOT EXISTS aqo;
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'true'; -- show AQO info for each node and entire query.
 SET aqo.show_hash = 'false'; -- a hash value is system-depended. Ignore it.
-SET aqo.join_threshold = 0;
 DO $d$
     BEGIN
         EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
@@ -100,15 +105,23 @@ SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
   SELECT * FROM frgn AS a, frgn AS b WHERE a.x=b.x;
 ') AS str WHERE str NOT LIKE '%Sort Method%';
-                    str                    
--------------------------------------------
- Foreign Scan (actual rows=1 loops=1)
+                            str                             
+------------------------------------------------------------
+ Merge Join (actual rows=1 loops=1)
    AQO not used
-   Relations: (frgn a) INNER JOIN (frgn b)
+   Merge Cond: (a.x = b.x)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: a.x
+         ->  Foreign Scan on frgn a (actual rows=1 loops=1)
+               AQO not used
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: b.x
+         ->  Foreign Scan on frgn b (actual rows=1 loops=1)
+               AQO not used
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(6 rows)
+(14 rows)
 
 -- Should learn on postgres_fdw nodes
 SELECT str FROM expln('

--- a/expected/aqo_forced.out
+++ b/expected/aqo_forced.out
@@ -1,3 +1,11 @@
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 CREATE TABLE aqo_test0(a int, b int, c int, d int);
 WITH RECURSIVE t(a, b, c, d)
 AS (
@@ -16,8 +24,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'controlled';
 EXPLAIN (COSTS FALSE)
 SELECT * FROM aqo_test0
@@ -82,11 +88,4 @@ DROP INDEX aqo_test0_idx_a;
 DROP TABLE aqo_test0;
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/aqo_intelligent.out
+++ b/expected/aqo_intelligent.out
@@ -1,3 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 CREATE TABLE aqo_test0(a int, b int, c int, d int);
 WITH RECURSIVE t(a, b, c, d)
 AS (
@@ -16,8 +23,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'intelligent';
 EXPLAIN SELECT * FROM aqo_test0
 WHERE a < 3 AND b < 3 AND c < 3 AND d < 3;
@@ -519,11 +524,4 @@ DROP INDEX aqo_test0_idx_a;
 DROP TABLE aqo_test0;
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/aqo_learn.out
+++ b/expected/aqo_learn.out
@@ -1,3 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 -- The function just copied from stats_ext.sql
 create function check_estimated_rows(text) returns table (estimated int, actual int)
 language plpgsql as
@@ -36,8 +43,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'intelligent';
 EXPLAIN SELECT * FROM aqo_test0
 WHERE a < 3 AND b < 3 AND c < 3 AND d < 3;
@@ -236,10 +241,10 @@ SELECT count(*) FROM tmp1;
 (1 row)
 
 -- Remove data on some unneeded instances of tmp1 table.
-SELECT * FROM aqo_cleanup();
- nfs | nfss 
------+------
-   9 |   18
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
+ t
 (1 row)
 
 -- Result of the query below should be empty
@@ -563,7 +568,7 @@ SELECT * FROM check_estimated_rows(
   'SELECT * FROM aqo_test1 AS t1, aqo_test1 AS t2 WHERE t1.a = t2.b');
  estimated | actual 
 -----------+--------
-        19 |     19
+        20 |     19
 (1 row)
 
 SELECT count(*) FROM
@@ -716,11 +721,4 @@ DROP INDEX aqo_test0_idx_a;
 DROP TABLE aqo_test0;
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/clean_aqo_data.out
+++ b/expected/clean_aqo_data.out
@@ -1,5 +1,10 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'learn';
 DROP TABLE IF EXISTS a;
 NOTICE:  table "a" does not exist, skipping
@@ -11,9 +16,9 @@ SELECT * FROM a;
 (0 rows)
 
 SELECT 'a'::regclass::oid AS a_oid \gset
-SELECT true FROM aqo_cleanup();
- bool 
-------
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
  t
 (1 row)
 
@@ -54,9 +59,9 @@ SELECT count(*) FROM aqo_query_stat WHERE
 (1 row)
 
 DROP TABLE a;
-SELECT true FROM aqo_cleanup();
- bool 
-------
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
  t
 (1 row)
 
@@ -119,7 +124,7 @@ SELECT 'b'::regclass::oid AS b_oid \gset
 SELECT count(*) FROM aqo_data WHERE :a_oid=ANY(oids);
  count 
 -------
-     2
+     3
 (1 row)
 
 SELECT count(*) FROM aqo_queries WHERE
@@ -175,9 +180,9 @@ SELECT count(*) FROM aqo_query_stat WHERE
 (1 row)
 
 DROP TABLE a;
-SELECT true FROM aqo_cleanup();
- bool 
-------
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
  t
 (1 row)
 
@@ -253,9 +258,9 @@ SELECT count(*) FROM aqo_query_stat WHERE
 (1 row)
 
 DROP TABLE b;
-SELECT true FROM aqo_cleanup();
- bool 
-------
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
  t
 (1 row)
 

--- a/expected/feature_subspace.out
+++ b/expected/feature_subspace.out
@@ -1,7 +1,12 @@
 -- This test related to some issues on feature subspace calculation
-CREATE EXTENSION aqo;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'learn';
-SET aqo.join_threshold = 0;
 SET aqo.show_details = 'on';
 CREATE TABLE a AS (SELECT gs AS x FROM generate_series(1,10) AS gs);
 CREATE TABLE b AS (SELECT gs AS x FROM generate_series(1,100) AS gs);
@@ -46,20 +51,23 @@ SELECT str AS result
 FROM expln('
 SELECT * FROM b LEFT JOIN a USING (x);') AS str
 WHERE str NOT LIKE '%Memory%';
-                       result                       
-----------------------------------------------------
- Hash Left Join (actual rows=100 loops=1)
-   AQO: rows=10, error=-900%
-   Hash Cond: (b.x = a.x)
-   ->  Seq Scan on b (actual rows=100 loops=1)
-         AQO: rows=100, error=0%
-   ->  Hash (actual rows=10 loops=1)
+                       result                        
+-----------------------------------------------------
+ Merge Left Join (actual rows=100 loops=1)
+   AQO not used
+   Merge Cond: (b.x = a.x)
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: b.x
+         ->  Seq Scan on b (actual rows=100 loops=1)
+               AQO not used
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: a.x
          ->  Seq Scan on a (actual rows=10 loops=1)
-               AQO: rows=10, error=0%
+               AQO not used
  Using aqo: true
  AQO mode: LEARN
  JOINS: 0
-(11 rows)
+(14 rows)
 
 -- Look into the reason: two JOINs from different classes have the same FSS.
 SELECT to_char(d1.targets[1], 'FM999.00') AS target FROM aqo_data d1
@@ -72,10 +80,4 @@ WHERE 'a'::regclass = ANY (d1.oids) AND 'b'::regclass = ANY (d1.oids) order by t
 (2 rows)
 
 DROP TABLE a,b CASCADE;
-SELECT true FROM aqo_reset();
- bool 
-------
- t
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/forced_stat_collection.out
+++ b/expected/forced_stat_collection.out
@@ -1,5 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 \set citizens	1000
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'disabled';
 SET aqo.force_collect_stat = 'off';
 CREATE TABLE person (
@@ -19,7 +25,6 @@ INSERT INTO person (id,age,gender,passport)
 	 		END
 	 FROM (SELECT *, 14+(id % 60) AS age FROM generate_series(1, :citizens) id) AS q1
 	);
-CREATE EXTENSION aqo;
 SET aqo.force_collect_stat = 'on';
 SELECT count(*) FROM person WHERE age<18;
  count 
@@ -64,10 +69,4 @@ SELECT query_text FROM aqo_query_texts ORDER BY (md5(query_text));
 (3 rows)
 
 DROP TABLE person;
-SELECT 1 FROM aqo_reset(); -- Full remove of ML data before the end
- ?column? 
-----------
-        1
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/gucs.out
+++ b/expected/gucs.out
@@ -1,4 +1,11 @@
-CREATE EXTENSION aqo;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 -- Utility tool. Allow to filter system-dependent strings from an explain output.
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
 BEGIN
@@ -7,15 +14,14 @@ BEGIN
     RETURN;
 END;
 $$ LANGUAGE PLPGSQL;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = true;
 CREATE TABLE t(x int);
 INSERT INTO t (x) (SELECT * FROM generate_series(1, 100) AS gs);
 ANALYZE t;
-SELECT true FROM aqo_reset(); -- Remember! DROP EXTENSION doesn't remove any AQO data gathered.
- bool 
-------
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
  t
 (1 row)
 
@@ -124,9 +130,9 @@ SELECT count(*) FROM aqo_query_stat;
      1
 (1 row)
 
-SELECT true FROM aqo_reset(); -- Remove one record from all tables
- bool 
-------
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
  t
 (1 row)
 

--- a/expected/look_a_like.out
+++ b/expected/look_a_like.out
@@ -1,11 +1,12 @@
-CREATE EXTENSION aqo;
-SELECT true FROM aqo_reset();
- bool 
-------
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
  t
 (1 row)
 
-SET aqo.join_threshold = 0;
+SET aqo.wide_search = 'on';
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'on';
 set aqo.show_hash = 'off';
@@ -550,14 +551,9 @@ WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%' and str NOT L
  JOINS: 1
 (24 rows)
 
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
+RESET aqo.wide_search;
+DROP EXTENSION aqo CASCADE;
 DROP TABLE a;
 DROP TABLE b;
 DROP TABLE c;
 DROP FUNCTION expln;
-DROP EXTENSION aqo CASCADE;

--- a/expected/parallel_workers.out
+++ b/expected/parallel_workers.out
@@ -1,6 +1,12 @@
 -- Specifically test AQO machinery for queries uses partial paths and executed
 -- with parallel workers.
-CREATE EXTENSION aqo;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 -- Utility tool. Allow to filter system-dependent strings from explain output.
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
 BEGIN
@@ -9,7 +15,6 @@ BEGIN
     RETURN;
 END;
 $$ LANGUAGE PLPGSQL;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = true;
 -- Be generous with a number parallel workers to test the machinery

--- a/expected/plancache.out
+++ b/expected/plancache.out
@@ -1,6 +1,11 @@
 -- Tests on interaction of AQO with cached plans.
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'intelligent';
 SET aqo.show_details = 'on';
 SET aqo.show_hash = 'off';
@@ -44,10 +49,4 @@ SELECT * FROM f1();
 
 DROP FUNCTION f1;
 DROP TABLE test CASCADE;
-SELECT true FROM aqo_reset();
- bool 
-------
- t
-(1 row)
-
 DROP EXTENSION aqo;

--- a/expected/relocatable.out
+++ b/expected/relocatable.out
@@ -1,5 +1,10 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'learn'; -- use this mode for unconditional learning
 CREATE TABLE test AS (SELECT id, 'payload' || id FROM generate_series(1,100) id);
 ANALYZE test;

--- a/expected/schema.out
+++ b/expected/schema.out
@@ -1,5 +1,3 @@
-DROP EXTENSION IF EXISTS aqo CASCADE;
-NOTICE:  extension "aqo" does not exist, skipping
 DROP SCHEMA IF EXISTS test CASCADE;
 NOTICE:  schema "test" does not exist, skipping
 -- Check Zero-schema path behaviour
@@ -12,7 +10,12 @@ ERROR:  no schema has been selected to create in
 CREATE SCHEMA IF NOT EXISTS test1;
 SET search_path TO test1, public;
 CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'intelligent';
 CREATE TABLE test (id SERIAL, data TEXT);
 INSERT INTO test (data) VALUES ('string');

--- a/expected/statement_timeout.out
+++ b/expected/statement_timeout.out
@@ -17,37 +17,43 @@ BEGIN
         END IF;
     END LOOP;
 END; $$;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 CREATE TABLE t AS SELECT * FROM generate_series(1,50) AS x;
 ANALYZE t;
 DELETE FROM t WHERE x > 5; -- Force optimizer to make overestimated prediction.
-CREATE EXTENSION IF NOT EXISTS aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'off';
 SET aqo.learn_statement_timeout = 'on';
-SET statement_timeout = 100; -- [0.1s]
+SET statement_timeout = 80; -- [0.1s]
 SELECT *, pg_sleep(0.1) FROM t;
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;'); -- haven't any partial data
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;'); -- haven't any partial data
  check_estimated_rows 
 ----------------------
                    50
 (1 row)
 
 -- Don't learn because running node has smaller cardinality than an optimizer prediction
-SET statement_timeout = 400;
+SET statement_timeout = 350;
 SELECT *, pg_sleep(0.1) FROM t;
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
  check_estimated_rows 
 ----------------------
                    50
 (1 row)
 
 -- We have a real learning data.
-SET statement_timeout = 8000;
+SET statement_timeout = 800;
 SELECT *, pg_sleep(0.1) FROM t;
  x | pg_sleep 
 ---+----------
@@ -58,7 +64,7 @@ SELECT *, pg_sleep(0.1) FROM t;
  5 | 
 (5 rows)
 
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
  check_estimated_rows 
 ----------------------
                     5
@@ -68,33 +74,33 @@ SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
 DELETE FROM t WHERE x > 2;
 ANALYZE t;
 INSERT INTO t (x) (SELECT * FROM generate_series(3,5) AS x);
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
 (1 row)
 
-SET statement_timeout = 100;
+SET statement_timeout = 80;
 SELECT *, pg_sleep(0.1) FROM t; -- Not learned
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
  check_estimated_rows 
 ----------------------
                     2
 (1 row)
 
-SET statement_timeout = 500;
+SET statement_timeout = 350;
 SELECT *, pg_sleep(0.1) FROM t; -- Learn!
 NOTICE:  [AQO] Time limit for execution of the statement was expired. AQO tried to learn on partial data.
 ERROR:  canceling statement due to statement timeout
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
  check_estimated_rows 
 ----------------------
-                    4
+                    3
 (1 row)
 
-SET statement_timeout = 800;
+SET statement_timeout = 550;
 SELECT *, pg_sleep(0.1) FROM t; -- Get reliable data
  x | pg_sleep 
 ---+----------
@@ -105,17 +111,17 @@ SELECT *, pg_sleep(0.1) FROM t; -- Get reliable data
  5 | 
 (5 rows)
 
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
  check_estimated_rows 
 ----------------------
                     5
 (1 row)
 
 -- Interrupted query should immediately appear in aqo_data
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
 (1 row)
 
 SET statement_timeout = 500;
@@ -134,10 +140,10 @@ SELECT count(*) FROM aqo_data; -- Must be one
      1
 (1 row)
 
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
 (1 row)
 
 DROP TABLE t;

--- a/expected/temp_tables.out
+++ b/expected/temp_tables.out
@@ -1,5 +1,12 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
+SET aqo.wide_search = 'on';
 SET aqo.mode = 'learn';
 CREATE TEMP TABLE tt();
 CREATE TABLE pt();
@@ -48,10 +55,10 @@ SELECT count(*) FROM aqo_data; -- Don't bother about false negatives because of 
 (1 row)
 
 DROP TABLE tt;
-SELECT * FROM aqo_cleanup();
- nfs | nfss 
------+------
-   0 |    0
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
+ t
 (1 row)
 
 SELECT count(*) FROM aqo_data; -- Should return the same as previous call above
@@ -61,10 +68,10 @@ SELECT count(*) FROM aqo_data; -- Should return the same as previous call above
 (1 row)
 
 DROP TABLE pt;
-SELECT * FROM aqo_cleanup();
- nfs | nfss 
------+------
-   3 |   10
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
+ t
 (1 row)
 
 SELECT count(*) FROM aqo_data; -- Should be 0
@@ -133,10 +140,10 @@ SELECT * FROM check_estimated_rows('
 
 SET aqo.mode = 'forced'; -- Now we use all fss records for each query
 DROP TABLE pt;
-SELECT * FROM aqo_cleanup();
- nfs | nfss 
------+------
-   2 |    5
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
+ t
 (1 row)
 
 CREATE TABLE pt AS SELECT x AS x, (x % 10) AS y FROM generate_series(1,100) AS x;
@@ -184,12 +191,8 @@ SELECT * FROM check_estimated_rows('
        100 |      0
 (1 row)
 
+-- Clear common parts of AQO state
+RESET aqo.wide_search;
+DROP EXTENSION aqo CASCADE;
 DROP TABLE pt CASCADE;
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
-DROP EXTENSION aqo;
 DROP FUNCTION check_estimated_rows;

--- a/expected/top_queries.out
+++ b/expected/top_queries.out
@@ -1,5 +1,11 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 SET aqo.mode = 'disabled';
 SET aqo.force_collect_stat = 'on';
 --
@@ -94,11 +100,5 @@ ORDER BY (md5(query_text));
  SELECT count(*) AS cnt FROM ttp WHERE cnt % 100 = 0;                                           |      1
  SELECT count(*) FROM (SELECT x, y FROM t1 GROUP BY GROUPING SETS ((x,y), (x), (y), ())) AS q1; |      1
 (3 rows)
-
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
 
 DROP EXTENSION aqo;

--- a/expected/unsupported.out
+++ b/expected/unsupported.out
@@ -1,4 +1,10 @@
-CREATE EXTENSION aqo;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 -- Utility tool. Allow to filter system-dependent strings from an explain output.
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
 BEGIN
@@ -7,7 +13,6 @@ BEGIN
   RETURN;
 END;
 $$ LANGUAGE PLPGSQL;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'on';
 DROP TABLE IF EXISTS t;
@@ -52,7 +57,7 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
    AQO not used
    Group Key: x
    ->  Seq Scan on t (actual rows=801 loops=1)
-         AQO: rows=801, error=0%
+         AQO not used
          Filter: (x > 3)
          Rows Removed by Filter: 199
  Using aqo: true
@@ -406,7 +411,7 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
            ->  Aggregate (actual rows=1 loops=1000)
                  AQO not used
                  ->  Seq Scan on t t0 (actual rows=50 loops=1000)
-                       AQO: rows=50, error=0%
+                       AQO not used
                        Filter: (x = t.x)
                        Rows Removed by Filter: 950
          SubPlan 2
@@ -616,10 +621,10 @@ SELECT count(*) FROM aqo_data; -- Just to detect some changes in the logic. May 
     44
 (1 row)
 
-SELECT * FROM aqo_cleanup();
- nfs | nfss 
------+------
-  13 |   44
+SELECT true AS success FROM aqo_cleanup();
+ success 
+---------
+ t
 (1 row)
 
 SELECT count(*) FROM aqo_data; -- No one row should be returned
@@ -636,11 +641,5 @@ ORDER BY (md5(query_text),error) DESC;
  error | query_text 
 -------+------------
 (0 rows)
-
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
 
 DROP EXTENSION aqo;

--- a/expected/update_functions.out
+++ b/expected/update_functions.out
@@ -1,3 +1,11 @@
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
+(1 row)
+
 CREATE TABLE aqo_test1(a int, b int);
 WITH RECURSIVE t(a, b)
 AS (
@@ -16,8 +24,6 @@ AS (
 ) INSERT INTO aqo_test2 (SELECT * FROM t);
 CREATE INDEX aqo_test2_idx_a ON aqo_test2 (a);
 ANALYZE aqo_test2;
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode='intelligent';
 SELECT count(*) FROM aqo_test1 a, aqo_test2 b WHERE a.a=b.a;
  count 
@@ -134,10 +140,10 @@ CREATE TABLE aqo_query_texts_dump AS SELECT * FROM aqo_query_texts;
 CREATE TABLE aqo_queries_dump AS SELECT * FROM aqo_queries;
 CREATE TABLE aqo_query_stat_dump AS SELECT * FROM aqo_query_stat;
 CREATE TABLE aqo_data_dump AS SELECT * FROM aqo_data;
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
+SELECT true AS success FROM aqo_reset();
+ success 
+---------
+ t
 (1 row)
 
 --
@@ -411,12 +417,6 @@ SELECT aqo_data_update(1, 1, 1, '{{1}, {2}}', '{1}', '{1}', '{1, 2, 3}');
 (1 row)
 
 SET aqo.mode='disabled';
-SELECT 1 FROM aqo_reset();
- ?column? 
-----------
-        1
-(1 row)
-
-DROP EXTENSION aqo;
+DROP EXTENSION aqo CASCADE;
 DROP TABLE aqo_test1, aqo_test2;
 DROP TABLE aqo_query_texts_dump, aqo_queries_dump, aqo_query_stat_dump, aqo_data_dump;

--- a/sql/aqo_fdw.sql
+++ b/sql/aqo_fdw.sql
@@ -4,13 +4,13 @@
 -- Aggregate push-down
 -- Push-down of groupings with HAVING clause.
 
-CREATE EXTENSION aqo;
-CREATE EXTENSION postgres_fdw;
+CREATE EXTENSION IF NOT EXISTS aqo;
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+SELECT true AS success FROM aqo_reset();
 
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'true'; -- show AQO info for each node and entire query.
 SET aqo.show_hash = 'false'; -- a hash value is system-depended. Ignore it.
-SET aqo.join_threshold = 0;
 
 DO $d$
     BEGIN

--- a/sql/aqo_forced.sql
+++ b/sql/aqo_forced.sql
@@ -1,3 +1,7 @@
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 CREATE TABLE aqo_test0(a int, b int, c int, d int);
 WITH RECURSIVE t(a, b, c, d)
 AS (
@@ -17,9 +21,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 
 SET aqo.mode = 'controlled';
 
@@ -53,11 +54,7 @@ WHERE a < 5 AND b < 5 AND c < 5 AND d < 5;
 
 DROP INDEX aqo_test0_idx_a;
 DROP TABLE aqo_test0;
-
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
-
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
 
 DROP EXTENSION aqo;

--- a/sql/aqo_intelligent.sql
+++ b/sql/aqo_intelligent.sql
@@ -1,3 +1,6 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 CREATE TABLE aqo_test0(a int, b int, c int, d int);
 WITH RECURSIVE t(a, b, c, d)
 AS (
@@ -17,9 +20,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 
 SET aqo.mode = 'intelligent';
 
@@ -214,8 +214,5 @@ DROP TABLE aqo_test0;
 
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
-
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
 
 DROP EXTENSION aqo;

--- a/sql/aqo_learn.sql
+++ b/sql/aqo_learn.sql
@@ -1,3 +1,6 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 -- The function just copied from stats_ext.sql
 create function check_estimated_rows(text) returns table (estimated int, actual int)
 language plpgsql as
@@ -38,9 +41,6 @@ AS (
 ) INSERT INTO aqo_test1 (SELECT * FROM t);
 CREATE INDEX aqo_test1_idx_a ON aqo_test1 (a);
 ANALYZE aqo_test1;
-
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 
 SET aqo.mode = 'intelligent';
 
@@ -124,7 +124,7 @@ WHERE t1.a = t2.b AND t2.a = t3.b AND t3.a = t4.b;
 SELECT count(*) FROM tmp1;
 
 -- Remove data on some unneeded instances of tmp1 table.
-SELECT * FROM aqo_cleanup();
+SELECT true AS success FROM aqo_cleanup();
 
 -- Result of the query below should be empty
 SELECT * FROM aqo_query_texts aqt1, aqo_query_texts aqt2
@@ -313,8 +313,5 @@ DROP INDEX aqo_test0_idx_a;
 DROP TABLE aqo_test0;
 DROP INDEX aqo_test1_idx_a;
 DROP TABLE aqo_test1;
-
--- XXX: extension dropping doesn't clear file storage. Do it manually.
-SELECT 1 FROM aqo_reset();
 
 DROP EXTENSION aqo;

--- a/sql/clean_aqo_data.sql
+++ b/sql/clean_aqo_data.sql
@@ -1,5 +1,6 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 SET aqo.mode = 'learn';
 
 DROP TABLE IF EXISTS a;
@@ -7,7 +8,7 @@ DROP TABLE IF EXISTS b;
 CREATE TABLE a();
 SELECT * FROM a;
 SELECT 'a'::regclass::oid AS a_oid \gset
-SELECT true FROM aqo_cleanup();
+SELECT true AS success FROM aqo_cleanup();
 
 /*
  * lines with a_oid in aqo_data,
@@ -27,7 +28,7 @@ SELECT count(*) FROM aqo_query_stat WHERE
         aqo_queries.fs = ANY(SELECT aqo_data.fs FROM aqo_data WHERE :a_oid=ANY(oids)));
 
 DROP TABLE a;
-SELECT true FROM aqo_cleanup();
+SELECT true AS success FROM aqo_cleanup();
 
 /*
  * lines with a_oid in aqo_data,
@@ -79,7 +80,7 @@ SELECT count(*) FROM aqo_query_stat WHERE
         aqo_queries.fs = ANY(SELECT aqo_data.fs FROM aqo_data WHERE :b_oid=ANY(oids)));
 
 DROP TABLE a;
-SELECT true FROM aqo_cleanup();
+SELECT true AS success FROM aqo_cleanup();
 
 /*
  * lines corresponding to a_oid and both a_oid's fs deleted in aqo_data,
@@ -115,7 +116,7 @@ SELECT count(*) FROM aqo_query_stat WHERE
             aqo_queries.fs = aqo_queries.queryid);
 
 DROP TABLE b;
-SELECT true FROM aqo_cleanup();
+SELECT true AS success FROM aqo_cleanup();
 
 -- lines corresponding to b_oid in theese tables deleted
 SELECT count(*) FROM aqo_data WHERE :b_oid=ANY(oids);

--- a/sql/feature_subspace.sql
+++ b/sql/feature_subspace.sql
@@ -1,9 +1,9 @@
 -- This test related to some issues on feature subspace calculation
 
-CREATE EXTENSION aqo;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
 
 SET aqo.mode = 'learn';
-SET aqo.join_threshold = 0;
 SET aqo.show_details = 'on';
 
 CREATE TABLE a AS (SELECT gs AS x FROM generate_series(1,10) AS gs);
@@ -41,5 +41,5 @@ JOIN aqo_data d2 ON (d1.fs <> d2.fs AND d1.fss = d2.fss)
 WHERE 'a'::regclass = ANY (d1.oids) AND 'b'::regclass = ANY (d1.oids) order by target;
 
 DROP TABLE a,b CASCADE;
-SELECT true FROM aqo_reset();
+
 DROP EXTENSION aqo;

--- a/sql/forced_stat_collection.sql
+++ b/sql/forced_stat_collection.sql
@@ -1,6 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 \set citizens	1000
 
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'disabled';
 SET aqo.force_collect_stat = 'off';
 
@@ -23,7 +25,6 @@ INSERT INTO person (id,age,gender,passport)
 	 FROM (SELECT *, 14+(id % 60) AS age FROM generate_series(1, :citizens) id) AS q1
 	);
 
-CREATE EXTENSION aqo;
 SET aqo.force_collect_stat = 'on';
 
 SELECT count(*) FROM person WHERE age<18;
@@ -46,5 +47,5 @@ ORDER BY (cardinality_error_without_aqo);
 SELECT query_text FROM aqo_query_texts ORDER BY (md5(query_text));
 
 DROP TABLE person;
-SELECT 1 FROM aqo_reset(); -- Full remove of ML data before the end
+
 DROP EXTENSION aqo;

--- a/sql/gucs.sql
+++ b/sql/gucs.sql
@@ -1,4 +1,6 @@
-CREATE EXTENSION aqo;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
 
 -- Utility tool. Allow to filter system-dependent strings from an explain output.
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
@@ -9,7 +11,6 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = true;
 
@@ -17,7 +18,7 @@ CREATE TABLE t(x int);
 INSERT INTO t (x) (SELECT * FROM generate_series(1, 100) AS gs);
 ANALYZE t;
 
-SELECT true FROM aqo_reset(); -- Remember! DROP EXTENSION doesn't remove any AQO data gathered.
+SELECT true AS success FROM aqo_reset();
 -- Check AQO addons to explain (the only stable data)
 SELECT regexp_replace(
         str,'Query Identifier: -?\m\d+\M','Query Identifier: N','g') as str FROM expln('
@@ -46,7 +47,7 @@ SELECT obj_description('aqo_reset'::regproc::oid);
 
 -- Check stat reset
 SELECT count(*) FROM aqo_query_stat;
-SELECT true FROM aqo_reset(); -- Remove one record from all tables
+SELECT true AS success FROM aqo_reset();
 SELECT count(*) FROM aqo_query_stat;
 
 DROP EXTENSION aqo;

--- a/sql/look_a_like.sql
+++ b/sql/look_a_like.sql
@@ -1,6 +1,9 @@
-CREATE EXTENSION aqo;
-SELECT true FROM aqo_reset();
-SET aqo.join_threshold = 0;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
+SET aqo.wide_search = 'on';
+
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'on';
 set aqo.show_hash = 'off';
@@ -136,9 +139,10 @@ FROM expln('
 SELECT * FROM (A LEFT JOIN B ON A.x1 = B.y1) sc left join C on sc.x1=C.z1;') AS str
 WHERE str NOT LIKE 'Query Identifier%' and str NOT LIKE '%Memory%' and str NOT LIKE '%Sort Method%';
 
-SELECT 1 FROM aqo_reset();
+RESET aqo.wide_search;
+DROP EXTENSION aqo CASCADE;
+
 DROP TABLE a;
 DROP TABLE b;
 DROP TABLE c;
 DROP FUNCTION expln;
-DROP EXTENSION aqo CASCADE;

--- a/sql/parallel_workers.sql
+++ b/sql/parallel_workers.sql
@@ -1,7 +1,8 @@
 -- Specifically test AQO machinery for queries uses partial paths and executed
 -- with parallel workers.
 
-CREATE EXTENSION aqo;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
 
 -- Utility tool. Allow to filter system-dependent strings from explain output.
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
@@ -12,7 +13,6 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = true;
 
@@ -51,7 +51,6 @@ SELECT count(*) FROM
 WHERE q1.id = q2.id;') AS str
 WHERE str NOT LIKE '%Workers%' AND str NOT LIKE '%Sort Method%'
   AND str NOT LIKE '%Gather Merge%';
-
 
 RESET parallel_tuple_cost;
 RESET parallel_setup_cost;

--- a/sql/plancache.sql
+++ b/sql/plancache.sql
@@ -1,7 +1,8 @@
 -- Tests on interaction of AQO with cached plans.
 
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 SET aqo.mode = 'intelligent';
 SET aqo.show_details = 'on';
 SET aqo.show_hash = 'off';
@@ -44,5 +45,5 @@ SELECT * FROM f1();
 
 DROP FUNCTION f1;
 DROP TABLE test CASCADE;
-SELECT true FROM aqo_reset();
+
 DROP EXTENSION aqo;

--- a/sql/relocatable.sql
+++ b/sql/relocatable.sql
@@ -1,5 +1,6 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 SET aqo.mode = 'learn'; -- use this mode for unconditional learning
 
 CREATE TABLE test AS (SELECT id, 'payload' || id FROM generate_series(1,100) id);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,4 +1,3 @@
-DROP EXTENSION IF EXISTS aqo CASCADE;
 DROP SCHEMA IF EXISTS test CASCADE;
 
 -- Check Zero-schema path behaviour
@@ -11,7 +10,7 @@ CREATE EXTENSION aqo;  -- fail
 CREATE SCHEMA IF NOT EXISTS test1;
 SET search_path TO test1, public;
 CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+SELECT true AS success FROM aqo_reset();
 SET aqo.mode = 'intelligent';
 
 CREATE TABLE test (id SERIAL, data TEXT);

--- a/sql/statement_timeout.sql
+++ b/sql/statement_timeout.sql
@@ -18,56 +18,58 @@ BEGIN
     END LOOP;
 END; $$;
 
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 CREATE TABLE t AS SELECT * FROM generate_series(1,50) AS x;
 ANALYZE t;
 DELETE FROM t WHERE x > 5; -- Force optimizer to make overestimated prediction.
 
-CREATE EXTENSION IF NOT EXISTS aqo;
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'off';
 SET aqo.learn_statement_timeout = 'on';
 
-SET statement_timeout = 100; -- [0.1s]
+SET statement_timeout = 80; -- [0.1s]
 SELECT *, pg_sleep(0.1) FROM t;
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;'); -- haven't any partial data
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;'); -- haven't any partial data
 
 -- Don't learn because running node has smaller cardinality than an optimizer prediction
-SET statement_timeout = 400;
+SET statement_timeout = 350;
 SELECT *, pg_sleep(0.1) FROM t;
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
 
 -- We have a real learning data.
-SET statement_timeout = 8000;
+SET statement_timeout = 800;
 SELECT *, pg_sleep(0.1) FROM t;
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
 
 -- Force to make an underestimated prediction
 DELETE FROM t WHERE x > 2;
 ANALYZE t;
 INSERT INTO t (x) (SELECT * FROM generate_series(3,5) AS x);
-SELECT 1 FROM aqo_reset();
+SELECT true AS success FROM aqo_reset();
 
-SET statement_timeout = 100;
+SET statement_timeout = 80;
 SELECT *, pg_sleep(0.1) FROM t; -- Not learned
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
 
-SET statement_timeout = 500;
+SET statement_timeout = 350;
 SELECT *, pg_sleep(0.1) FROM t; -- Learn!
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
 
-SET statement_timeout = 800;
+SET statement_timeout = 550;
 SELECT *, pg_sleep(0.1) FROM t; -- Get reliable data
-SELECT check_estimated_rows('SELECT *, pg_sleep(1) FROM t;');
+SELECT check_estimated_rows('SELECT *, pg_sleep(0.1) FROM t;');
 
 -- Interrupted query should immediately appear in aqo_data
-SELECT 1 FROM aqo_reset();
+SELECT true AS success FROM aqo_reset();
 SET statement_timeout = 500;
 SELECT count(*) FROM aqo_data; -- Must be zero
 SELECT x, pg_sleep(0.1) FROM t WHERE x > 0;
 SELECT count(*) FROM aqo_data; -- Must be one
 
-SELECT 1 FROM aqo_reset();
+SELECT true AS success FROM aqo_reset();
 DROP TABLE t;
 DROP EXTENSION aqo;
 DROP FUNCTION check_estimated_rows;

--- a/sql/top_queries.sql
+++ b/sql/top_queries.sql
@@ -1,5 +1,7 @@
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 SET aqo.mode = 'disabled';
 SET aqo.force_collect_stat = 'on';
 
@@ -51,5 +53,4 @@ FROM aqo_cardinality_error(false) ce, aqo_query_texts aqt
 WHERE ce.id = aqt.queryid
 ORDER BY (md5(query_text));
 
-SELECT 1 FROM aqo_reset();
 DROP EXTENSION aqo;

--- a/sql/unsupported.sql
+++ b/sql/unsupported.sql
@@ -1,4 +1,5 @@
-CREATE EXTENSION aqo;
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
 
 -- Utility tool. Allow to filter system-dependent strings from an explain output.
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
@@ -9,7 +10,6 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
-SET aqo.join_threshold = 0;
 SET aqo.mode = 'learn';
 SET aqo.show_details = 'on';
 
@@ -182,7 +182,7 @@ ORDER BY (md5(query_text),error) DESC;
 DROP TABLE t,t1 CASCADE; -- delete all tables used in the test
 
 SELECT count(*) FROM aqo_data; -- Just to detect some changes in the logic. May some false positives really bother us here?
-SELECT * FROM aqo_cleanup();
+SELECT true AS success FROM aqo_cleanup();
 SELECT count(*) FROM aqo_data; -- No one row should be returned
 
 -- Look for any remaining queries in the ML storage.
@@ -191,5 +191,4 @@ FROM aqo_cardinality_error(true) cef, aqo_query_texts aqt
 WHERE aqt.queryid = cef.id
 ORDER BY (md5(query_text),error) DESC;
 
-SELECT 1 FROM aqo_reset();
 DROP EXTENSION aqo;

--- a/sql/update_functions.sql
+++ b/sql/update_functions.sql
@@ -1,3 +1,7 @@
+-- Preliminaries
+CREATE EXTENSION IF NOT EXISTS aqo;
+SELECT true AS success FROM aqo_reset();
+
 CREATE TABLE aqo_test1(a int, b int);
 WITH RECURSIVE t(a, b)
 AS (
@@ -17,9 +21,6 @@ AS (
 ) INSERT INTO aqo_test2 (SELECT * FROM t);
 CREATE INDEX aqo_test2_idx_a ON aqo_test2 (a);
 ANALYZE aqo_test2;
-
-CREATE EXTENSION aqo;
-SET aqo.join_threshold = 0;
 
 SET aqo.mode='intelligent';
 
@@ -61,7 +62,7 @@ CREATE TABLE aqo_queries_dump AS SELECT * FROM aqo_queries;
 CREATE TABLE aqo_query_stat_dump AS SELECT * FROM aqo_query_stat;
 CREATE TABLE aqo_data_dump AS SELECT * FROM aqo_data;
 
-SELECT 1 FROM aqo_reset();
+SELECT true AS success FROM aqo_reset();
 
 --
 -- aqo_query_texts_update() testing.
@@ -202,8 +203,8 @@ SELECT aqo_data_update(1, 1, 1, '{{1}}', '{1}', '{1, 1}', '{1, 2, 3}');
 SELECT aqo_data_update(1, 1, 1, '{{1}, {2}}', '{1}', '{1}', '{1, 2, 3}');
 
 SET aqo.mode='disabled';
-SELECT 1 FROM aqo_reset();
-DROP EXTENSION aqo;
+
+DROP EXTENSION aqo CASCADE;
 
 DROP TABLE aqo_test1, aqo_test2;
 DROP TABLE aqo_query_texts_dump, aqo_queries_dump, aqo_query_stat_dump, aqo_data_dump;

--- a/t/001_pgbench.pl
+++ b/t/001_pgbench.pl
@@ -20,6 +20,8 @@ my $TRANSACTIONS = 1000;
 my $CLIENTS = 10;
 my $THREADS = 10;
 
+$ENV{PGOPTIONS}="";
+
 # Change pgbench parameters according to the environment variable.
 if (defined $ENV{TRANSACTIONS})
 {

--- a/t/002_pg_stat_statements_aqo.pl
+++ b/t/002_pg_stat_statements_aqo.pl
@@ -23,6 +23,9 @@ my $CLIENTS = 10;
 my $THREADS = 10;
 my $query_id;
 
+# Disable connection default settings, forced by PGOPTIONS in AQO Makefile
+$ENV{PGOPTIONS}="";
+
 # General purpose variables.
 my $res;
 my $total_classes;


### PR DESCRIPTION
Move GUCs, which can be changed in runtime, from global regression tests conf to first executed test 'aqo_disabled.sql'. There we set these values by ALTER SYSTEM/pg_reload_conf() and use them during the test. Also, we call aqo_reset() at the start of each test.

And a bit more:
1. Avoid to show a number of records in AQO ML storage - it can depend on optimizer settings and quite unstable (in progress).
2. Use aliases query in output to avoid unstability of naming of anonymous columns.