### PR TITLE
Fix to avoid bad situation, we will not have capable to calculate que…

### DIFF
--- a/expected/aqo_fdw.out
+++ b/expected/aqo_fdw.out
@@ -62,7 +62,7 @@ SELECT x FROM frgn;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
                             str                            
 -----------------------------------------------------------
  Foreign Scan on public.frgn (actual rows=1 loops=1)
@@ -77,7 +77,7 @@ SELECT str FROM expln('
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
                             str                            
 -----------------------------------------------------------
  Foreign Scan on public.frgn (actual rows=1 loops=1)
@@ -89,9 +89,11 @@ SELECT str FROM expln('
  JOINS: 0
 (7 rows)
 
+SELECT str FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT x FROM frgn WHERE x < -10; -- AQO ignores constants
-                  QUERY PLAN                  
+') AS str WHERE str NOT LIKE 'Query Identifier%';
+                     str                      
 ----------------------------------------------
  Foreign Scan on frgn (actual rows=0 loops=1)
    AQO: rows=1, error=100%
@@ -127,7 +129,7 @@ SELECT str FROM expln('
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x=b.x;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
                                                   str                                                   
 --------------------------------------------------------------------------------------------------------
  Foreign Scan (actual rows=1 loops=1)
@@ -276,7 +278,7 @@ SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
                                                   str                                                   
 --------------------------------------------------------------------------------------------------------
  Foreign Scan (actual rows=0 loops=1)

--- a/expected/unsupported.out
+++ b/expected/unsupported.out
@@ -535,7 +535,7 @@ SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, SUMMARY OFF, TIMING OFF)
     SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1') AS str
-WHERE str NOT LIKE '%Heap Blocks%';
+WHERE str NOT LIKE '%Heap Blocks%' and str NOT LIKE 'Query Identifier%';
                                str                               
 -----------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
@@ -555,9 +555,11 @@ WHERE str NOT LIKE '%Heap Blocks%';
 
 -- Best choice is ...
 ANALYZE t;
+SELECT str FROM expln('
 EXPLAIN (COSTS OFF)
 	SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
-              QUERY PLAN               
+') AS str WHERE str NOT LIKE 'Query Identifier%';
+                  str                  
 ---------------------------------------
  Aggregate
    AQO not used

--- a/preprocessing.c
+++ b/preprocessing.c
@@ -127,6 +127,7 @@ aqo_planner(Query *parse,
 {
 	bool			query_is_stored = false;
 	MemoryContext	oldctx;
+	int query_id_enabled_temp = compute_query_id;
 
 	 /*
 	  * We do not work inside an parallel worker now by reason of insert into
@@ -156,7 +157,11 @@ aqo_planner(Query *parse,
 
 	/* Check unlucky case (get a hash of zero) */
 	if (parse->queryId == UINT64CONST(0))
+	{
+		compute_query_id = COMPUTE_QUERY_ID_ON;
 		JumbleQuery(parse, query_string);
+		compute_query_id = query_id_enabled_temp;
+	}
 
 	Assert(parse->utilityStmt == NULL);
 	Assert(parse->queryId != UINT64CONST(0));

--- a/sql/aqo_fdw.sql
+++ b/sql/aqo_fdw.sql
@@ -47,14 +47,15 @@ SELECT x FROM frgn;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT x FROM frgn WHERE x < 10;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
+SELECT str FROM expln('
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 SELECT x FROM frgn WHERE x < -10; -- AQO ignores constants
-
+') AS str WHERE str NOT LIKE 'Query Identifier%';
 -- Trivial JOIN push-down.
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
@@ -65,7 +66,7 @@ SELECT str FROM expln('
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x=b.x;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
 
 CREATE TABLE local_a(aid int primary key, aval text);
 CREATE TABLE local_b(bid int primary key, aid int references local_a(aid), bval text);
@@ -139,7 +140,7 @@ SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF, VERBOSE)
     SELECT * FROM frgn AS a, frgn AS b WHERE a.x<b.x;
-') AS str;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
 
 DROP EXTENSION aqo CASCADE;
 DROP EXTENSION postgres_fdw CASCADE;

--- a/sql/unsupported.sql
+++ b/sql/unsupported.sql
@@ -165,12 +165,14 @@ SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
 SELECT str FROM expln('
   EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, SUMMARY OFF, TIMING OFF)
     SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1') AS str
-WHERE str NOT LIKE '%Heap Blocks%';
+WHERE str NOT LIKE '%Heap Blocks%' and str NOT LIKE 'Query Identifier%';
 
 -- Best choice is ...
 ANALYZE t;
+SELECT str FROM expln('
 EXPLAIN (COSTS OFF)
 	SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
+') AS str WHERE str NOT LIKE 'Query Identifier%';
 
 -- XXX: Do we stuck into an unstable behavior of an error value?
 -- Live with this variant of the test for some time.


### PR DESCRIPTION
…ry_id

with JambleQuery, if compute_query_id is off.
We set value of the compute_query_id parameter is 'on', while during calculate query_id operation and after its completion, we will return its initial value.
This solution seemed to be simple, but reliable.