### PR TITLE
Add specific initial script for AQO 1.6.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ EXTRA_INSTALL = contrib/postgres_fdw contrib/pg_stat_statements
 
 DATA = aqo--1.0.sql aqo--1.0--1.1.sql aqo--1.1--1.2.sql aqo--1.2.sql \
 		aqo--1.2--1.3.sql aqo--1.3--1.4.sql aqo--1.4--1.5.sql \
-		aqo--1.5--1.6.sql
+		aqo--1.5--1.6.sql aqo--1.6.sql
 
 ifdef USE_PGXS
 PG_CONFIG ?= pg_config

--- a/aqo--1.6.sql
+++ b/aqo--1.6.sql
@@ -1,0 +1,210 @@
+/* contrib/aqo/aqo--1.6.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION aqo" to load this file. \quit
+
+--
+-- Get cardinality error of queries the last time they were executed.
+-- IN:
+-- controlled - show queries executed under a control of AQO (true);
+-- executed without an AQO control, but AQO has a stat on the query (false).
+--
+-- OUT:
+-- num - sequental number. Smaller number corresponds to higher error.
+-- id - ID of a query.
+-- fshash - feature space. Usually equal to zero or ID.
+-- error - AQO error that calculated on plan nodes of the query.
+-- nexecs - number of executions of queries associated with this ID.
+--
+CREATE FUNCTION aqo_cardinality_error(controlled boolean)
+RETURNS TABLE(num integer, id bigint, fshash bigint, error double precision, nexecs bigint)
+AS 'MODULE_PATHNAME', 'aqo_cardinality_error'
+LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION aqo_cardinality_error(boolean) IS
+'Get cardinality error of queries the last time they were executed. Order queries according to an error value.';
+
+--
+-- Remove unneeded rows from the AQO ML storage.
+-- For common feature space, remove rows from aqo_data only.
+-- For custom feature space - remove all rows related to the space from all AQO
+-- tables even if only one oid for one feature subspace of the space is illegal.
+-- Returns number of deleted rows from aqo_queries and aqo_data tables.
+--
+CREATE FUNCTION aqo_cleanup(OUT nfs integer, OUT nfss integer)
+RETURNS record
+AS 'MODULE_PATHNAME', 'aqo_cleanup'
+LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION aqo_cleanup() IS
+'Remove unneeded rows from the AQO ML storage';
+
+CREATE FUNCTION aqo_disable_class(queryid bigint)
+RETURNS void
+AS 'MODULE_PATHNAME', 'aqo_disable_query'
+LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION aqo_disable_class(bigint) IS
+'Set learn_aqo, use_aqo and auto_tuning into false for a class of queries with specific queryid.';
+
+--
+-- Remove query class settings, text, statistics and ML data from AQO storage.
+-- Return number of FSS records, removed from the storage.
+--
+CREATE FUNCTION aqo_drop_class(queryid bigint)
+RETURNS integer
+AS 'MODULE_PATHNAME', 'aqo_drop_class'
+LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION aqo_drop_class(bigint) IS
+'Remove info about an query class from AQO ML knowledge base.';
+
+CREATE FUNCTION aqo_enable_class(queryid bigint)
+RETURNS void
+AS 'MODULE_PATHNAME', 'aqo_enable_query'
+LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION aqo_enable_class(bigint) IS
+'Set learn_aqo, use_aqo and auto_tuning (in intelligent mode) into true for a class of queries with specific queryid.';
+
+--
+-- Show execution time of queries, for which AQO has statistics.
+-- controlled - show stat on executions where AQO was used for cardinality
+-- estimations, or not used (controlled = false).
+-- Last case is possible in disabled mode with aqo.force_collect_stat = 'on'.
+--
+CREATE FUNCTION aqo_execution_time(controlled boolean)
+RETURNS TABLE(num integer, id bigint, fshash bigint, exec_time double precision, nexecs bigint)
+AS 'MODULE_PATHNAME', 'aqo_execution_time'
+LANGUAGE C STRICT VOLATILE;
+COMMENT ON FUNCTION aqo_execution_time(boolean) IS
+'Get execution time of queries. If controlled = true (AQO could advise cardinality estimations), show time of last execution attempt. Another case (AQO not used), return an average value of execution time across all known executions.';
+
+CREATE FUNCTION aqo_memory_usage(
+  OUT name text,
+  OUT allocated_size int,
+  OUT used_size int
+)
+RETURNS SETOF record
+AS $$
+  SELECT name, total_bytes, used_bytes FROM pg_backend_memory_contexts
+  WHERE name LIKE 'AQO%'
+  UNION
+  SELECT name, allocated_size, size FROM pg_shmem_allocations
+  WHERE name LIKE 'AQO%';
+$$ LANGUAGE SQL;
+COMMENT ON FUNCTION aqo_memory_usage() IS
+'Show allocated sizes and used sizes of aqo`s memory contexts and hash tables';
+
+--
+-- Update or insert an aqo_data
+-- table record for given 'fs' & 'fss'.
+--
+
+CREATE FUNCTION aqo_data_update(
+  fs			bigint,
+  fss			integer,
+  nfeatures		integer,
+  features		double precision[][],
+  targets		double precision[],
+  reliability	double precision[],
+  oids			Oid[])
+RETURNS bool
+AS 'MODULE_PATHNAME', 'aqo_data_update'
+LANGUAGE C VOLATILE;
+
+CREATE FUNCTION aqo_queries_update(
+  queryid bigint, fs bigint, learn_aqo bool, use_aqo bool, auto_tuning bool)
+RETURNS bool
+AS 'MODULE_PATHNAME', 'aqo_queries_update'
+LANGUAGE C VOLATILE;
+
+--
+-- Update or insert an aqo_query_stat
+-- table record for given 'queryid'.
+--
+CREATE FUNCTION aqo_query_stat_update(
+  queryid						bigint,
+  execution_time_with_aqo		double precision[],
+  execution_time_without_aqo	double precision[],
+  planning_time_with_aqo		double precision[],
+  planning_time_without_aqo		double precision[],
+  cardinality_error_with_aqo	double precision[],
+  cardinality_error_without_aqo	double precision[],
+  executions_with_aqo			bigint,
+  executions_without_aqo		bigint)
+RETURNS bool
+AS 'MODULE_PATHNAME', 'aqo_query_stat_update'
+LANGUAGE C VOLATILE;
+
+--
+-- Update or insert an aqo_query_texts
+-- table record for given 'queryid'.
+--
+CREATE FUNCTION aqo_query_texts_update(
+  queryid bigint, query_text text)
+RETURNS bool
+AS 'MODULE_PATHNAME', 'aqo_query_texts_update'
+LANGUAGE C VOLATILE;
+
+--
+-- Remove all records in the AQO storage.
+-- Return number of rows removed.
+--
+CREATE FUNCTION aqo_reset() RETURNS bigint
+AS 'MODULE_PATHNAME', 'aqo_reset'
+LANGUAGE C PARALLEL SAFE;
+COMMENT ON FUNCTION aqo_reset() IS
+'Reset all data gathered by AQO';
+
+-- -----------------------------------------------------------------------------
+--
+-- VIEWs
+--
+-- -----------------------------------------------------------------------------
+
+CREATE FUNCTION aqo_data (
+  OUT fs			bigint,
+  OUT fss			integer,
+  OUT nfeatures		integer,
+  OUT features		double precision[][],
+  OUT targets		double precision[],
+  OUT reliability	double precision[],
+  OUT oids			Oid[]
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'aqo_data'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE FUNCTION aqo_queries (
+  OUT queryid                bigint,
+  OUT fs                     bigint,
+  OUT learn_aqo              boolean,
+  OUT use_aqo                boolean,
+  OUT auto_tuning            boolean,
+  OUT smart_timeout          bigint,
+  OUT count_increase_timeout bigint
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'aqo_queries'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE FUNCTION aqo_query_stat (
+  OUT queryid						bigint,
+  OUT execution_time_with_aqo		double precision[],
+  OUT execution_time_without_aqo	double precision[],
+  OUT planning_time_with_aqo		double precision[],
+  OUT planning_time_without_aqo		double precision[],
+  OUT cardinality_error_with_aqo	double precision[],
+  OUT cardinality_error_without_aqo	double precision[],
+  OUT executions_with_aqo bigint,
+  OUT executions_without_aqo		bigint
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'aqo_query_stat'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE FUNCTION aqo_query_texts(OUT queryid bigint, OUT query_text text)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'aqo_query_texts'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE VIEW aqo_data AS SELECT * FROM aqo_data();
+CREATE VIEW aqo_queries AS SELECT * FROM aqo_queries();
+CREATE VIEW aqo_query_stat AS SELECT * FROM aqo_query_stat();
+CREATE VIEW aqo_query_texts AS SELECT * FROM aqo_query_texts();

--- a/expected/aqo_CVE-2020-14350.out
+++ b/expected/aqo_CVE-2020-14350.out
@@ -49,51 +49,32 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_status(hash bigint)
-RETURNS TABLE (
-  "learn"       BOOL,
-  "use aqo"     BOOL,
-  "auto tune"   BOOL,
-  "fspace hash" bigINT,
-  "t_naqo"      TEXT,
-  "err_naqo"    TEXT,
-  "iters"       BIGINT,
-  "t_aqo"       TEXT,
-  "err_aqo"     TEXT,
-  "iters_aqo"   BIGINT
-)
+CREATE FUNCTION aqo_reset()
+RETURNS bigint
 AS $$
 BEGIN
+  RETURN 1;
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
 -- Test result (error expected)
 CREATE EXTENSION aqo;
-ERROR:  function "aqo_status" already exists with same argument types
+ERROR:  function "aqo_reset" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_status(hash bigint)
-RETURNS TABLE (
-  "learn"       BOOL,
-  "use aqo"     BOOL,
-  "auto tune"   BOOL,
-  "fspace hash" bigINT,
-  "t_naqo"      TEXT,
-  "err_naqo"    TEXT,
-  "iters"       BIGINT,
-  "t_aqo"       TEXT,
-  "err_aqo"     TEXT,
-  "iters_aqo"   BIGINT
-)
+CREATE OR REPLACE FUNCTION aqo_reset()
+RETURNS bigint
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
+  RETURN 2;
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
-SELECT aqo_status(42);
- aqo_status 
-------------
-(0 rows)
+SELECT aqo_reset();
+ aqo_reset 
+-----------
+         2
+(1 row)
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
@@ -103,7 +84,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_status(bigint);
+DROP FUNCTION aqo_reset();
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 3
@@ -208,29 +189,31 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_clear_hist(hash bigint)
-RETURNS VOID
+CREATE FUNCTION aqo_drop_class(queryid bigint)
+RETURNS integer
 AS $$
 BEGIN
+  RETURN 1;
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
 -- Test result (error expected)
 CREATE EXTENSION aqo;
-ERROR:  function "aqo_clear_hist" already exists with same argument types
+ERROR:  function "aqo_drop_class" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_clear_hist(hash bigint)
-RETURNS VOID
+CREATE OR REPLACE FUNCTION aqo_drop_class(queryid bigint)
+RETURNS integer
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
+  RETURN 2;
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
-SELECT aqo_clear_hist(42);
- aqo_clear_hist 
+SELECT aqo_drop_class(42);
+ aqo_drop_class 
 ----------------
- 
+              2
 (1 row)
 
 SET ROLE regress_hacker;
@@ -241,7 +224,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_clear_hist(bigint);
+DROP FUNCTION aqo_drop_class(bigint);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 6
@@ -254,8 +237,8 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_drop(hash bigint)
-RETURNS VOID
+CREATE FUNCTION aqo_execution_time(controlled boolean)
+RETURNS TABLE(num integer, id bigint, fshash bigint, exec_time double precision, nexecs bigint)
 AS $$
 BEGIN
 END
@@ -263,21 +246,20 @@ $$ LANGUAGE plpgsql;
 RESET ROLE;
 -- Test result (error expected)
 CREATE EXTENSION aqo;
-ERROR:  function "aqo_drop" already exists with same argument types
+ERROR:  function "aqo_execution_time" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_drop(hash bigint)
-RETURNS VOID
+CREATE OR REPLACE FUNCTION aqo_execution_time(controlled boolean)
+RETURNS TABLE(num integer, id bigint, fshash bigint, exec_time double precision, nexecs bigint)
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
-SELECT aqo_drop(42);
- aqo_drop 
-----------
- 
-(1 row)
+SELECT aqo_execution_time(true);
+ aqo_execution_time 
+--------------------
+(0 rows)
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
@@ -287,7 +269,7 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_drop(bigint);
+DROP FUNCTION aqo_execution_time(boolean);
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
 -- Test 7
@@ -300,8 +282,8 @@ SHOW is_superuser;
  off
 (1 row)
 
-CREATE FUNCTION aqo_ne_queries()
-RETURNS SETOF int
+CREATE FUNCTION aqo_memory_usage(OUT name text, OUT allocated_size int, OUT used_size int)
+RETURNS SETOF record
 AS $$
 BEGIN
 END
@@ -309,19 +291,19 @@ $$ LANGUAGE plpgsql;
 RESET ROLE;
 -- Test result (error expected)
 CREATE EXTENSION aqo;
-ERROR:  function "aqo_ne_queries" already exists with same argument types
+ERROR:  function "aqo_memory_usage" already exists with same argument types
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_ne_queries()
-RETURNS SETOF int
+CREATE OR REPLACE FUNCTION aqo_memory_usage(OUT name text, OUT allocated_size int, OUT used_size int)
+RETURNS SETOF record
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
 END
 $$ LANGUAGE plpgsql;
 RESET ROLE;
-SELECT aqo_ne_queries();
- aqo_ne_queries 
-----------------
+SELECT aqo_memory_usage();
+ aqo_memory_usage 
+------------------
 (0 rows)
 
 SET ROLE regress_hacker;
@@ -332,43 +314,9 @@ SHOW is_superuser;
 (1 row)
 
 RESET ROLE;
-DROP FUNCTION aqo_ne_queries();
+DROP FUNCTION aqo_memory_usage();
 DROP EXTENSION IF EXISTS aqo;
 NOTICE:  extension "aqo" does not exist, skipping
--- Test 8
-RESET ROLE;
-ALTER ROLE regress_hacker NOSUPERUSER;
-SET ROLE regress_hacker;
-SHOW is_superuser;
- is_superuser 
---------------
- off
-(1 row)
-
-CREATE FUNCTION aqo_migrate_to_1_1_get_pk(rel text)
-RETURNS regclass
-AS $$
-DECLARE
-  ret regclass;
-BEGIN
-  ALTER ROLE regress_hacker SUPERUSER;
-  SELECT * FROM aqo_migrate_to_1_1_get_pk(rel::regclass) INTO ret;
-  RETURN ret;
-END
-$$ LANGUAGE plpgsql;
-RESET ROLE;
-CREATE EXTENSION aqo;
--- Test result (must be 'off')
-SET ROLE regress_hacker;
-SHOW is_superuser;
- is_superuser 
---------------
- off
-(1 row)
-
-RESET ROLE;
-DROP FUNCTION aqo_migrate_to_1_1_get_pk(text);
-DROP EXTENSION IF EXISTS aqo;
 -- Cleanup
 RESET ROLE;
 DROP OWNED BY regress_hacker CASCADE;

--- a/sql/aqo_CVE-2020-14350.sql
+++ b/sql/aqo_CVE-2020-14350.sql
@@ -44,21 +44,11 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_status(hash bigint)
-RETURNS TABLE (
-  "learn"       BOOL,
-  "use aqo"     BOOL,
-  "auto tune"   BOOL,
-  "fspace hash" bigINT,
-  "t_naqo"      TEXT,
-  "err_naqo"    TEXT,
-  "iters"       BIGINT,
-  "t_aqo"       TEXT,
-  "err_aqo"     TEXT,
-  "iters_aqo"   BIGINT
-)
+CREATE FUNCTION aqo_reset()
+RETURNS bigint
 AS $$
 BEGIN
+  RETURN 1;
 END
 $$ LANGUAGE plpgsql;
 
@@ -67,33 +57,23 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_status(hash bigint)
-RETURNS TABLE (
-  "learn"       BOOL,
-  "use aqo"     BOOL,
-  "auto tune"   BOOL,
-  "fspace hash" bigINT,
-  "t_naqo"      TEXT,
-  "err_naqo"    TEXT,
-  "iters"       BIGINT,
-  "t_aqo"       TEXT,
-  "err_aqo"     TEXT,
-  "iters_aqo"   BIGINT
-)
+CREATE OR REPLACE FUNCTION aqo_reset()
+RETURNS bigint
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
+  RETURN 2;
 END
 $$ LANGUAGE plpgsql;
 
 RESET ROLE;
-SELECT aqo_status(42);
+SELECT aqo_reset();
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_status(bigint);
+DROP FUNCTION aqo_reset();
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 3
@@ -177,10 +157,11 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_clear_hist(hash bigint)
-RETURNS VOID
+CREATE FUNCTION aqo_drop_class(queryid bigint)
+RETURNS integer
 AS $$
 BEGIN
+  RETURN 1;
 END
 $$ LANGUAGE plpgsql;
 
@@ -189,22 +170,23 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_clear_hist(hash bigint)
-RETURNS VOID
+CREATE OR REPLACE FUNCTION aqo_drop_class(queryid bigint)
+RETURNS integer
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
+  RETURN 2;
 END
 $$ LANGUAGE plpgsql;
 
 RESET ROLE;
-SELECT aqo_clear_hist(42);
+SELECT aqo_drop_class(42);
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_clear_hist(bigint);
+DROP FUNCTION aqo_drop_class(bigint);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 6
@@ -214,8 +196,8 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_drop(hash bigint)
-RETURNS VOID
+CREATE FUNCTION aqo_execution_time(controlled boolean)
+RETURNS TABLE(num integer, id bigint, fshash bigint, exec_time double precision, nexecs bigint)
 AS $$
 BEGIN
 END
@@ -226,8 +208,8 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_drop(hash bigint)
-RETURNS VOID
+CREATE OR REPLACE FUNCTION aqo_execution_time(controlled boolean)
+RETURNS TABLE(num integer, id bigint, fshash bigint, exec_time double precision, nexecs bigint)
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
@@ -235,13 +217,13 @@ END
 $$ LANGUAGE plpgsql;
 
 RESET ROLE;
-SELECT aqo_drop(42);
+SELECT aqo_execution_time(true);
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_drop(bigint);
+DROP FUNCTION aqo_execution_time(boolean);
 DROP EXTENSION IF EXISTS aqo;
 
 -- Test 7
@@ -251,8 +233,8 @@ ALTER ROLE regress_hacker NOSUPERUSER;
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
-CREATE FUNCTION aqo_ne_queries()
-RETURNS SETOF int
+CREATE FUNCTION aqo_memory_usage(OUT name text, OUT allocated_size int, OUT used_size int)
+RETURNS SETOF record
 AS $$
 BEGIN
 END
@@ -263,8 +245,8 @@ RESET ROLE;
 CREATE EXTENSION aqo;
 
 SET ROLE regress_hacker;
-CREATE OR REPLACE FUNCTION aqo_ne_queries()
-RETURNS SETOF int
+CREATE OR REPLACE FUNCTION aqo_memory_usage(OUT name text, OUT allocated_size int, OUT used_size int)
+RETURNS SETOF record
 AS $$
 BEGIN
   ALTER ROLE regress_hacker SUPERUSER;
@@ -272,43 +254,13 @@ END
 $$ LANGUAGE plpgsql;
 
 RESET ROLE;
-SELECT aqo_ne_queries();
+SELECT aqo_memory_usage();
 
 SET ROLE regress_hacker;
 SHOW is_superuser;
 
 RESET ROLE;
-DROP FUNCTION aqo_ne_queries();
-DROP EXTENSION IF EXISTS aqo;
-
--- Test 8
-RESET ROLE;
-ALTER ROLE regress_hacker NOSUPERUSER;
-
-SET ROLE regress_hacker;
-SHOW is_superuser;
-
-CREATE FUNCTION aqo_migrate_to_1_1_get_pk(rel text)
-RETURNS regclass
-AS $$
-DECLARE
-  ret regclass;
-BEGIN
-  ALTER ROLE regress_hacker SUPERUSER;
-  SELECT * FROM aqo_migrate_to_1_1_get_pk(rel::regclass) INTO ret;
-  RETURN ret;
-END
-$$ LANGUAGE plpgsql;
-
-RESET ROLE;
-CREATE EXTENSION aqo;
-
--- Test result (must be 'off')
-SET ROLE regress_hacker;
-SHOW is_superuser;
-
-RESET ROLE;
-DROP FUNCTION aqo_migrate_to_1_1_get_pk(text);
+DROP FUNCTION aqo_memory_usage();
 DROP EXTENSION IF EXISTS aqo;
 
 -- Cleanup


### PR DESCRIPTION
It mostly caused by desire of reducing number of failures 001_pgbench.pl test on WINDOWS OSes (it is related to speed of file descriptor allocations in the test, where we CREATE/DROP extensions competitively by several threads.

Also, the aqo_CVE-2020-14350 test is corrected.