### PR TITLE
Enhancement. Buildfarm have detected curious unstability in the paral…

### DIFF
--- a/expected/parallel_workers.out
+++ b/expected/parallel_workers.out
@@ -68,53 +68,52 @@ WHERE q1.id = q2.id; -- Learning stage
 
 -- XXX: Why grouping prediction isn't working here?
 SELECT str FROM expln('
-EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT count(*) FROM
   (SELECT id FROM t WHERE id % 100 = 0 GROUP BY (id)) AS q1,
   (SELECT max(id) AS id, payload FROM t
     WHERE id % 101 = 0 GROUP BY (payload)) AS q2
 WHERE q1.id = q2.id;') AS str
-WHERE str NOT LIKE '%Workers%' AND str NOT LIKE '%Sort Method%'
-  AND str NOT LIKE '%Gather Merge%';
+WHERE str NOT LIKE '%Workers%';
                                                str                                                
 --------------------------------------------------------------------------------------------------
- Aggregate (actual rows=1 loops=1)
+ Aggregate
    AQO not used
-   ->  Merge Join (actual rows=0 loops=1)
+   ->  Merge Join
          AQO not used
          Merge Cond: (q2.id = t_1.id)
-         ->  Sort (actual rows=1 loops=1)
+         ->  Sort
                Sort Key: q2.id
-               ->  Subquery Scan on q2 (actual rows=1 loops=1)
+               ->  Subquery Scan on q2
                      AQO not used
-                     ->  Finalize GroupAggregate (actual rows=1 loops=1)
+                     ->  Finalize GroupAggregate
                            AQO not used
                            Group Key: t.payload
+                           ->  Gather Merge
                                  AQO not used
-                                 ->  Partial GroupAggregate (actual rows=1 loops=3)
+                                 ->  Partial GroupAggregate
                                        AQO not used
                                        Group Key: t.payload
-                                       ->  Sort (actual rows=330 loops=3)
+                                       ->  Sort
                                              AQO not used
                                              Sort Key: t.payload
-                                             ->  Parallel Seq Scan on t (actual rows=330 loops=3)
-                                                   AQO: rows=991, error=0%
+                                             ->  Parallel Seq Scan on t
+                                                   AQO: rows=991
                                                    Filter: ((id % '101'::numeric) = '0'::numeric)
-                                                   Rows Removed by Filter: 33003
-         ->  Group (actual rows=1000 loops=1)
+         ->  Group
                AQO not used
                Group Key: t_1.id
+               ->  Gather Merge
                      AQO not used
-                     ->  Group (actual rows=333 loops=3)
+                     ->  Group
                            AQO not used
                            Group Key: t_1.id
-                           ->  Sort (actual rows=333 loops=3)
+                           ->  Sort
                                  AQO not used
                                  Sort Key: t_1.id
-                                 ->  Parallel Seq Scan on t t_1 (actual rows=333 loops=3)
-                                       AQO: rows=991, error=-1%
+                                 ->  Parallel Seq Scan on t t_1
+                                       AQO: rows=991
                                        Filter: ((id % '100'::numeric) = '0'::numeric)
-                                       Rows Removed by Filter: 33000
  Using aqo: true
  AQO mode: LEARN
  JOINS: 1

--- a/sql/parallel_workers.sql
+++ b/sql/parallel_workers.sql
@@ -43,14 +43,13 @@ SELECT count(*) FROM
 WHERE q1.id = q2.id; -- Learning stage
 -- XXX: Why grouping prediction isn't working here?
 SELECT str FROM expln('
-EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT count(*) FROM
   (SELECT id FROM t WHERE id % 100 = 0 GROUP BY (id)) AS q1,
   (SELECT max(id) AS id, payload FROM t
     WHERE id % 101 = 0 GROUP BY (payload)) AS q2
 WHERE q1.id = q2.id;') AS str
-WHERE str NOT LIKE '%Workers%' AND str NOT LIKE '%Sort Method%'
-  AND str NOT LIKE '%Gather Merge%';
+WHERE str NOT LIKE '%Workers%';
 
 RESET parallel_tuple_cost;
 RESET parallel_setup_cost;


### PR DESCRIPTION
…lel_workers

test: EXPLAIN of Partial Aggregate sometimes showed 0 rows instead 1. It is a race: parallel workers ran when main process have read all underlying tuples.

Use explain without analyze to avoid such a problem. As I see, we don't lose anything important.