### PR TITLE
Stable13 reducing the memory overhead.

### DIFF
--- a/aqo.c
+++ b/aqo.c
@@ -2,7 +2,7 @@
  * aqo.c
  *		Adaptive query optimization extension
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/aqo.c
@@ -91,6 +91,9 @@ MemoryContext 		AQOPredictMemCtx = NULL;
 
 /* Is released at the end of learning */
 MemoryContext 		AQOLearnMemCtx = NULL;
+
+/* Is released at the end of load/store routines */
+MemoryContext 		AQOStorageMemCtx = NULL;
 
 /* Additional plan info */
 int njoins;
@@ -342,6 +345,12 @@ _PG_init(void)
 	 */
 	AQOLearnMemCtx = AllocSetContextCreate(AQOTopMemCtx,
 											 "AQOLearnMemoryContext",
+											 ALLOCSET_DEFAULT_SIZES);
+	/*
+	 * AQOStorageMemoryContext containe data for load/store routines.
+	 */
+	AQOStorageMemCtx = AllocSetContextCreate(AQOTopMemCtx,
+											 "AQOStorageMemoryContext",
 											 ALLOCSET_DEFAULT_SIZES);
 	RegisterResourceReleaseCallback(aqo_free_callback, NULL);
 	RegisterAQOPlanNodeMethods();

--- a/aqo.h
+++ b/aqo.h
@@ -105,7 +105,7 @@
  * Module storage.c is responsible for storage query settings and models
  * (i. e. all information which is used in extension).
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/aqo.h
@@ -232,6 +232,7 @@ extern MemoryContext AQOTopMemCtx;
 extern MemoryContext AQOCacheMemCtx;
 extern MemoryContext AQOPredictMemCtx;
 extern MemoryContext AQOLearnMemCtx;
+extern MemoryContext AQOStorageMemCtx;
 
 extern int aqo_statement_timeout;
 

--- a/auto_tuning.c
+++ b/auto_tuning.c
@@ -8,7 +8,7 @@
  *
  *******************************************************************************
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/auto_tuning.c

--- a/cardinality_estimation.c
+++ b/cardinality_estimation.c
@@ -8,7 +8,7 @@
  *
  *******************************************************************************
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/cardinality_estimation.c

--- a/cardinality_hooks.c
+++ b/cardinality_hooks.c
@@ -18,7 +18,7 @@
  *
  *******************************************************************************
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/cardinality_hooks.c
@@ -81,6 +81,7 @@ aqo_set_baserel_rows_estimate(PlannerInfo *root, RelOptInfo *rel)
 	if (!query_context.use_aqo)
 	{
 		MemoryContextSwitchTo(old_ctx_m);
+		MemoryContextReset(AQOPredictMemCtx);
 		goto default_estimator;
 	}
 
@@ -99,6 +100,7 @@ aqo_set_baserel_rows_estimate(PlannerInfo *root, RelOptInfo *rel)
 
 	/* Return to the caller's memory context. */
 	MemoryContextSwitchTo(old_ctx_m);
+	MemoryContextReset(AQOPredictMemCtx);
 
 	if (predicted < 0)
 		goto default_estimator;
@@ -190,12 +192,15 @@ aqo_get_parameterized_baserel_size(PlannerInfo *root,
 			cache_selectivity(current_hash, rel->relid, rte->relid,
 							  *((double *) lfirst(l2)));
 		}
+
+		pfree(args_hash);
+		pfree(eclass_hash);
 	}
 
 	if (!query_context.use_aqo)
 	{
 		MemoryContextSwitchTo(oldctx);
-
+		MemoryContextReset(AQOPredictMemCtx);
 		goto default_estimator;
 	}
 
@@ -210,6 +215,7 @@ aqo_get_parameterized_baserel_size(PlannerInfo *root,
 
 	/* Return to the caller's memory context */
 	MemoryContextSwitchTo(oldctx);
+	MemoryContextReset(AQOPredictMemCtx);
 
 	predicted_ppi_rows = predicted;
 	fss_ppi_hash = fss;
@@ -264,6 +270,7 @@ aqo_set_joinrel_size_estimates(PlannerInfo *root, RelOptInfo *rel,
 	if (!query_context.use_aqo)
 	{
 		MemoryContextSwitchTo(old_ctx_m);
+		MemoryContextReset(AQOPredictMemCtx);
 		goto default_estimator;
 	}
 
@@ -283,6 +290,7 @@ aqo_set_joinrel_size_estimates(PlannerInfo *root, RelOptInfo *rel,
 
 	/* Return to the caller's memory context */
 	MemoryContextSwitchTo(old_ctx_m);
+	MemoryContextReset(AQOPredictMemCtx);
 
 	rel->fss_hash = fss;
 
@@ -342,6 +350,7 @@ aqo_get_parameterized_joinrel_size(PlannerInfo *root,
 	if (!query_context.use_aqo)
 	{
 		MemoryContextSwitchTo(old_ctx_m);
+		MemoryContextReset(AQOPredictMemCtx);
 		goto default_estimator;
 	}
 
@@ -358,6 +367,7 @@ aqo_get_parameterized_joinrel_size(PlannerInfo *root,
 									 &fss);
 	/* Return to the caller's memory context */
 	MemoryContextSwitchTo(old_ctx_m);
+	MemoryContextReset(AQOPredictMemCtx);
 
 	predicted_ppi_rows = predicted;
 	fss_ppi_hash = fss;
@@ -445,6 +455,7 @@ aqo_estimate_num_groups(PlannerInfo *root, List *groupExprs,
 		grouped_rel->rows = predicted;
 		grouped_rel->fss_hash = fss;
 		MemoryContextSwitchTo(old_ctx_m);
+		MemoryContextReset(AQOPredictMemCtx);
 		return predicted;
 	}
 	else
@@ -455,6 +466,7 @@ aqo_estimate_num_groups(PlannerInfo *root, List *groupExprs,
 		grouped_rel->predicted_cardinality = -1;
 
 	MemoryContextSwitchTo(old_ctx_m);
+	MemoryContextReset(AQOPredictMemCtx);
 
 default_estimator:
 	if (aqo_estimate_num_groups_next)

--- a/expected/unsupported.out
+++ b/expected/unsupported.out
@@ -311,6 +311,59 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
  JOINS: 0
 (23 rows)
 
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
+	SELECT * FROM t WHERE
+			x = (SELECT x FROM t t0 WHERE t0.x = t.x LIMIT 1) AND
+			x IN (SELECT x FROM t t0 WHERE t0.x = t.x);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Seq Scan on t (actual rows=1000 loops=1)
+   AQO not used
+   Filter: ((x = (SubPlan 1)) AND (SubPlan 2))
+   SubPlan 1
+     ->  Limit (actual rows=1 loops=1000)
+           AQO not used
+           ->  Seq Scan on t t0 (actual rows=1 loops=1000)
+                 AQO not used
+                 Filter: (x = t.x)
+                 Rows Removed by Filter: 475
+   SubPlan 2
+     ->  Seq Scan on t t0_1 (actual rows=1 loops=1000)
+           AQO not used
+           Filter: (x = t.x)
+           Rows Removed by Filter: 475
+ Using aqo: true
+ AQO mode: LEARN
+ JOINS: 0
+(18 rows)
+
+-- No prediction for top SeqScan, because it fss is changed
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
+	SELECT * FROM t WHERE
+			x = (SELECT x FROM t t0 WHERE t0.x = t.x LIMIT 1) AND
+			x IN (SELECT x FROM t t0 WHERE t0.x = t.x);
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Seq Scan on t (actual rows=1000 loops=1)
+   AQO not used
+   Filter: ((SubPlan 2) AND (x = (SubPlan 1)))
+   SubPlan 2
+     ->  Seq Scan on t t0_1 (actual rows=1 loops=1000)
+           AQO: rows=1, error=0%
+           Filter: (x = t.x)
+           Rows Removed by Filter: 475
+   SubPlan 1
+     ->  Limit (actual rows=1 loops=1000)
+           AQO not used
+           ->  Seq Scan on t t0 (actual rows=1 loops=1000)
+                 AQO: rows=1, error=0%
+                 Filter: (x = t.x)
+                 Rows Removed by Filter: 475
+ Using aqo: true
+ AQO mode: LEARN
+ JOINS: 0
+(18 rows)
+
 -- It's OK to use the knowledge for a query with different constants.
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 	SELECT count(*) FROM t WHERE
@@ -580,6 +633,10 @@ ORDER BY (md5(query_text),error) DESC;
 -------+------------------------------------------------------------------------------------------------
  0.768 | SELECT count(*) FROM (SELECT count(*) FROM t1 GROUP BY (x,y)) AS q1;
  0.070 | SELECT count(*) FROM (SELECT * FROM t GROUP BY (x) HAVING x > 3) AS q1;
+ 1.554 | EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)                                         +
+       |         SELECT * FROM t WHERE                                                                 +
+       |                         x = (SELECT x FROM t t0 WHERE t0.x = t.x LIMIT 1) AND                 +
+       |                         x IN (SELECT x FROM t t0 WHERE t0.x = t.x);
  0.000 | SELECT count(*) FROM t WHERE x < 3 AND mod(x,3) = 1;
  0.000 | SELECT * FROM                                                                                 +
        |         (SELECT * FROM t WHERE x < 0) AS t0                                                   +
@@ -612,13 +669,13 @@ ORDER BY (md5(query_text),error) DESC;
        |                 JOIN                                                                          +
        |         (SELECT * FROM t WHERE x % 3 < (SELECT avg(x) FROM t t0 WHERE t0.x <> t.x)) AS q2     +
        |                 ON q1.x = q2.x+1;
-(13 rows)
+(14 rows)
 
 DROP TABLE t,t1 CASCADE; -- delete all tables used in the test
 SELECT count(*) FROM aqo_data; -- Just to detect some changes in the logic. May some false positives really bother us here?
  count 
 -------
-    44
+    48
 (1 row)
 
 SELECT true AS success FROM aqo_cleanup();

--- a/machine_learning.c
+++ b/machine_learning.c
@@ -12,7 +12,7 @@
  *
  *******************************************************************************
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/machine_learning.c

--- a/postprocessing.c
+++ b/postprocessing.c
@@ -9,7 +9,7 @@
  *
  *******************************************************************************
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/postprocessing.c
@@ -222,6 +222,12 @@ restore_selectivities(List *clauselist, List *relidslist, JoinType join_type,
 		Assert(*cur_sel >= 0);
 
 		lst = lappend(lst, cur_sel);
+	}
+
+	if (parametrized_sel)
+	{
+		pfree(args_hash);
+		pfree(eclass_hash);
 	}
 
 	return lst;
@@ -833,11 +839,11 @@ aqo_ExecutorEnd(QueryDesc *queryDesc)
 		}
 	}
 
-	selectivity_cache_clear();
 	cur_classes = ldelete_uint64(cur_classes, query_context.query_hash);
 
 end:
 	/* Release all AQO-specific memory, allocated during learning procedure */
+	selectivity_cache_clear();
 	MemoryContextSwitchTo(oldctx);
 	MemoryContextReset(AQOLearnMemCtx);
 

--- a/preprocessing.c
+++ b/preprocessing.c
@@ -49,7 +49,7 @@
  *
  *******************************************************************************
  *
- * Copyright (c) 2016-2022, Postgres Professional
+ * Copyright (c) 2016-2023, Postgres Professional
  *
  * IDENTIFICATION
  *	  aqo/preprocessing.c

--- a/sql/unsupported.sql
+++ b/sql/unsupported.sql
@@ -98,6 +98,16 @@ EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 		x = (SELECT avg(x) FROM t t0 WHERE t0.x = t.x + 21) OR
 		x IN (SELECT avg(x) FROM t t0 WHERE t0.x = t.x + 21);
 
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
+	SELECT * FROM t WHERE
+			x = (SELECT x FROM t t0 WHERE t0.x = t.x LIMIT 1) AND
+			x IN (SELECT x FROM t t0 WHERE t0.x = t.x);
+-- No prediction for top SeqScan, because it fss is changed
+EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
+	SELECT * FROM t WHERE
+			x = (SELECT x FROM t t0 WHERE t0.x = t.x LIMIT 1) AND
+			x IN (SELECT x FROM t t0 WHERE t0.x = t.x);
+
 -- It's OK to use the knowledge for a query with different constants.
 EXPLAIN (ANALYZE, COSTS OFF, SUMMARY OFF, TIMING OFF)
 	SELECT count(*) FROM t WHERE


### PR DESCRIPTION
Free some allocated memory right after use.
Reset AQOPredictMemCtx as soon as posible.
Remove learning attempts on SubPlan nodes.
Bugfix. Free allocated memory on save/load data.
Add memory context for storage.
Change copyright to 2016-2023.